### PR TITLE
added german (and some english) translations

### DIFF
--- a/parts/puavomenu/strings.py
+++ b/parts/puavomenu/strings.py
@@ -9,42 +9,49 @@ STRINGS = {
         'fi': 'Etsi...',
         'en': 'Search...',
         'sv': 'Sök...',
-        'de': 'Suchen...'
+        'de': 'Suchen...',
     },
 
     'search_no_results': {
         'fi': 'Ei osumia',
         'en': 'No hits',
+        'de': 'Keine Resultate',
     },
 
     'menu_empty_menu': {
         'fi': 'Tyhjä valikko',
         'en': 'Empty menu',
+        'de': 'Leeres Menu',
     },
 
     'menu_empty_category': {
         'fi': 'Tyhjä kategoria',
         'en': 'Empty category',
+        'de': 'Leere Kategorie',
     },
 
     'menu_no_data_at_all': {
         'fi': 'Ei valikkodataa? Tarkista tilanne!',
         'en': 'No menu data? Check the situation!',
+        'de': 'Kein Menu? Was ist hier los!',
     },
 
     'desktop_link_failed': {
         'en': 'Desktop link could not be created',
-        'fi': 'Työpöytäkuvaketta ei voitu luoda'
+        'fi': 'Työpöytäkuvaketta ei voitu luoda',
+        'de': 'Desktoplink konnte nicht erstellt werden',
     },
 
     'panel_link_failed': {
         'en': 'Panel icon could not be created',
         'fi': 'Paneelin kuvaketta ei voitu luoda',
+        'de': 'Panelicon konnte nicht erstellt werden',
     },
 
     'program_launching_failed': {
         'en': 'Could not launch a program',
         'fi': 'Ohjelmaa ei voitu käynnistää',
+        'de': 'Programm konnte nicht geöffnet werden',
     },
 
     # --------------------------------------------------------------------------
@@ -53,26 +60,31 @@ STRINGS = {
     'sb_avatar_hover': {
         'en': 'Edit your user profile',
         'fi': 'Muokkaa käyttäjäprofiiliasi',
+        'de': 'Ediere Benutzerprofil'
     },
 
     'sb_avatar_link_failed': {
         'en': 'Could not open the user preferences editor',
         'fi': 'Ei voitu avata käyttäjätietojen muokkausta',
+        'de': 'Konnte den Benutzerprofil-Editor nicht öffnen',
     },
 
     'sb_button_failed': {
         'en': 'Sidebar button action failed',
         'fi': 'Sivupaneelin napin toiminnon suoritus ei onnistunut',
+        'de': 'Seitenleisten-Aktion konnte nicht ausgeführt werden',
     },
 
     'sb_change_password': {
         'en': 'Change your password',
         'fi': 'Vaihda salasana',
+        'de': 'Setze ein neues Passwort'
     },
 
     'sb_change_password_window_title': {
         'en': 'Change password',
         'fi': 'Vaihda salasana',
+        'de': 'Setze ein neues Passwort',
     },
 
     'sb_support': {
@@ -93,7 +105,7 @@ STRINGS = {
         'en': 'Lock screen',
         'fi': 'Lukitse näyttö',
         'sv': 'Lås skärmen',
-        'de': 'Bildschirm sperren'
+        'de': 'Bildschirm sperren',
     },
 
     'sb_hibernate': {
@@ -107,14 +119,14 @@ STRINGS = {
         'en': 'Logout',
         'fi': 'Kirjaudu ulos',
         'sv': 'Logga ut',
-        'de': 'Abmelden'
+        'de': 'Abmelden',
     },
 
     'sb_restart': {
         'en': 'Restart',
         'fi': 'Käynnistä uudelleen',
         'sv': 'Starta om',
-        'de': 'Neustarten'
+        'de': 'Neustarten',
     },
 
     'sb_shutdown': {
@@ -127,16 +139,19 @@ STRINGS = {
     'sb_changelog_title': {
         'en': 'Show changes in this version',
         'fi': 'Näytä muutokset tässä versiossa',
+        'de': 'Zeige Änderungen dieser Version',
     },
 
     'sb_changelog_window_title': {
         'en': 'Changelog',
         'fi': 'Muutosloki',
+        'de': 'Changelog',
     },
 
     'sb_changelog_link_failed': {
         'en': 'Could not show the changelog',
         'fi': 'Muutoslokin näyttäminen ei onnistunut',
+        'de': 'Changelog kann nicht angezeigt werden',
     },
 
     # --------------------------------------------------------------------------
@@ -146,20 +161,20 @@ STRINGS = {
         'fi': 'Lisää työpöydälle',
         'en': 'Add to desktop',
         'sv': 'Add to desktop',
-        'de': 'Add to desktop',
+        'de': 'Füge zum Schreibtisch hinzu',
     },
 
     'popup_add_to_panel': {
         'fi': 'Lisää alapaneeliin',
         'en': 'Add to bottom panel',
         'sv': 'Add to bottom panel',
-        'de': 'Add to bottom panel',
+        'de': 'Füge der unteren Leiste hinzu',
     },
 
     'popup_remove_from_faves': {
         'fi': 'Poista suosikeista',
         'en': 'Remove from favorites',
         'sv': 'Remove from favorites',
-        'de': 'Remove from favorites',
+        'de': 'Entferne Lesezeichen',
     },
 }

--- a/rules/puavomenu/templates/menudata.yaml
+++ b/rules/puavomenu/templates/menudata.yaml
@@ -267,27 +267,39 @@ programs:
   - libreoffice-base:
         name:
             fi: LibreOffice Tietokanta
+            de: LibreOffice Basis
+            en: LibreOffice Base
         keywords: libreoffice
   - libreoffice-calc:
-        keywords: calc, spreadsheet, libreoffice
+        keywords: calc, spreadsheet, libreoffice, excel
         name:
             fi: LibreOffice Taulukkolaskenta
+            de: LibreOffice Tabellenkalculation
+            en: LibreOffice Calc
   - libreoffice-draw:
         name:
             fi: LibreOffice Piirros
+            de: LibreOffice Zeichnung
+            en: LibreOffice Draw
         keywords: libreoffice
   - libreoffice-impress:
         name:
             fi: LibreOffice Esitys
-        keywords: libreoffice
+            de: LibreOffice Präsentation
+            en: LibreOffice Impress
+        keywords: libreoffice, powerpoint
   - libreoffice-math:
         name:
             fi: LibreOffice Kaava
+            de: LibreOffice Math
+            en: LibreOffice Math
         keywords: equation, libreoffice
   - libreoffice-writer:
         name:
             fi: LibreOffice Tekstinkäsittely
-        keywords: writer, kirjoitus, libreoffice
+            de: LibreOffice Textverarbeitung
+            en: LibreOffice Writer
+        keywords: writer, kirjoitus, libreoffice, word
   - lmms:
         name:
             en: LMMS - music production suite
@@ -778,7 +790,7 @@ menus:
             en: Internet-applications
             fi: Internet-sovellukset
             sv: Internet-program
-            de: Interent Programme
+            de: Internet Programme
         programs:
             - firefox
             - chromium
@@ -987,8 +999,11 @@ menus:
             en: Abitti-applications
             fi: Abitti-sovellukset
             sv: Abitti-applikationer
+            de: Prüfungsumgebung
         description:
             fi: Sovelluksia sähköiseen ylioppilastutkintoon
+            en: Programs for Grading Environment
+            de: Programme der Prüfungsumgebung
         icon: /usr/share/icons/oxygen/base/48x48/categories/applications-education.png
         programs:
             - gimp
@@ -1047,6 +1062,7 @@ menus:
         name:
             en: Physics
             fi: Fysiikka
+            de: Physik
         icon: /usr/share/icons/hicolor/64x64/apps/step.png
         programs:
             - org.kde.step
@@ -1059,6 +1075,7 @@ menus:
         name:
             en: Chemistry
             fi: Kemia
+            de: Chemie
         icon: /usr/share/icons/hicolor/48x48/apps/kalzium.png
         programs:
             - avogadro
@@ -1074,6 +1091,7 @@ menus:
         name:
             en: Mathematics
             fi: Matematiikka
+            de: Mathematik
         icon: /usr/share/icons/Faenza/categories/64/applications-interfacedesign.png
         programs:
             - tuxmath
@@ -1098,6 +1116,7 @@ menus:
         name:
             en: Geography
             fi: Maantieto
+            de: Geografie
         icon: /usr/share/tuxpaint/stamps/space/planets/3_earth.png
         programs:
             - marble-qt
@@ -1115,6 +1134,7 @@ menus:
         name:
             en: Environmental Science
             fi: Ympäristöoppi
+            de: Umweltwissenschaften
         icon: /usr/share/icons/Faenza/apps/64/tracker.png
         programs:
             - marble-qt
@@ -1131,6 +1151,7 @@ menus:
         name:
             en: Biology
             fi: Biologia
+            de: Biologie
         icon: /opt/webmenu/extra/icons/apps/applications-biology.svg
         programs:
             - perunakellari
@@ -1142,6 +1163,7 @@ menus:
         name:
             en: Social Sciences
             fi: Yhteiskuntaoppi
+            de: Sozialwissenschaften
         icon: /usr/share/icons/Faenza/emblems/64/emblem-sales.png
         programs:
             - ekapeli
@@ -1157,6 +1179,7 @@ menus:
         name:
             en: History
             fi: Historia
+            de: Geschichte
         icon: /usr/share/icons/hicolor/128x128/apps/freeciv-client.png
         programs:
             - marble-qt
@@ -1170,6 +1193,7 @@ menus:
         name:
             en: English and literature
             fi: Äidinkieli ja kirjallisuus
+            de: Englisch
         icon: /usr/share/icons/Faenza/apps/64/gnome-dictionary.png
         programs:
             - ekapeli
@@ -1189,6 +1213,7 @@ menus:
         name:
             en: Foreign languages
             fi: Vieraat kielet
+            de: Muttersprache
         icon: /usr/share/icons/oxygen/base/64x64/categories/applications-education-language.png
         programs:
             - libreoffice-writer
@@ -1201,6 +1226,7 @@ menus:
         name:
             en: Foreign languages
             fi: Toinen kotimainen
+            de: Fremdsprachen
         icon: /usr/share/icons/Faenza/apps/64/config-language.png
         programs:
             - ekapeli
@@ -1216,6 +1242,7 @@ menus:
         name:
             en: Music
             fi: Musiikki
+            de: Musik
         icon: /usr/share/icons/Faenza/apps/64/gmusicbrowser.png
         programs:
             - audacity
@@ -1232,6 +1259,7 @@ menus:
         name:
             en: Handicrafts
             fi: Käsityö
+            de: Gestalten
         icon: /usr/share/icons/Neu/128x128/categories/kcontrol.png
         programs:
             - pinta
@@ -1249,6 +1277,7 @@ menus:
         name:
             en: Arts
             fi: Kuvataide
+            de: Kunst
         icon: /usr/share/icons/Faenza/apps/64/mypaint.png
         programs:
             - tuxpaint
@@ -1268,6 +1297,7 @@ menus:
         name:
             en: Student counseling
             fi: Oppilaanohjaus
+            de: Schülerberatung
         icon: /usr/share/icons/oxygen/base/128x128/apps/system-users.png
         programs:
             - libreoffice-writer
@@ -1278,6 +1308,7 @@ menus:
         name:
             en: Home economics
             fi: Kotitalous
+            de: Wirtschaft
         icon: /opt/webmenu/extra/icons/apps/applications-java.svg
         programs:
             - libreoffice-writer
@@ -1289,6 +1320,7 @@ menus:
         name:
             en: Sports
             fi: Liikunta
+            de: Sport
         icon: /opt/webmenu/extra/icons/apps/applications-sports.svg
         programs:
             - libreoffice-writer
@@ -1300,6 +1332,7 @@ menus:
         name:
             en: Health
             fi: Terveystieto
+            de: Gesundheit
         icon: /usr/share/icons/gnome/48x48/emblems/emblem-favorite.png
         programs:
             - libreoffice-writer
@@ -1311,6 +1344,7 @@ menus:
         name:
             en: Ethics
             fi: Elämänkatsomustieto
+            de: Ethik
         icon: /usr/share/icons/oxygen/base/64x64/status/meeting-participant.png
         programs:
             - libreoffice-writer
@@ -1321,6 +1355,7 @@ menus:
         name:
             en: Religion
             fi: Uskonto
+            de: Religion
         icon: /usr/share/icons/oxygen/base/64x64/places/user-identity.png
         programs:
             - libreoffice-writer
@@ -1361,7 +1396,7 @@ categories:
             en: Subjects
             fi: Oppiaineet
             sv: Ämnen
-            de: Themen
+            de: Fächer
         position: 1
         menus:
             - menu-physics


### PR DESCRIPTION
Hi,

I added the german (and some english) translations to menudata.yaml. Like this the menu is in a (more or less) usefull state for finish/german/englisch.

Remarks: 
- (Most of) the webapplications and the abitti menu are not very usefull for switzerland/germany. They sould not show up at all.
- And the second tab should be country (maybe later also schooltype) dependent. This means one different tab content (themes/subject) for each country.

I suggest the following:

Adding a menu-country in conditions.yaml. This could be done easily with the shell $LANG (eg. de_CH.utf-8 for switzerland) or maybe with a new puavoconf entry.

When you agree, I'll make a PR with these country dependent menus and the needed adaptions in conditions.yaml

Basil 

