### PR TITLE
fix typo and title

### DIFF
--- a/rules/puavomenu/templates/menudata/50-default.yml
+++ b/rules/puavomenu/templates/menudata/50-default.yml
@@ -866,7 +866,7 @@ programs:
             en: Collaborative whiteboard
             fi: Yhteistoiminnallinen piirtotaulu
             sv: Kollaborativ whiteboard
-            de: Mit dem Whiteboard zusammenarbweiten
+            de: Mit dem Whiteboard zusammenarbeiten
         icon: /usr/share/icons/Faenza/mimetypes/96/text-html.png
         tags: default, education
   - wikipedia:
@@ -1221,7 +1221,7 @@ menus:
             en: "Interactive\nwhiteboards"
             fi: Älytaulut
             sv: Interaktiva tavlor
-            de: Interaktive Wandtafeln
+            de: Interaktive Tafeln
         icon: /usr/share/icons/Faenza/categories/96/applications-science.png
         condition: "!personally_administered"
         programs:


### PR DESCRIPTION
Fix a typo and replace "Interaktive Wandtafeln" with the better translation "Interaktive Tafeln"