### PR TITLE
WIP: Add a draft option for re-running display initialization commands.

### DIFF
--- a/parts/desktop-applet/puavo-desktop-applet
+++ b/parts/desktop-applet/puavo-desktop-applet
@@ -833,8 +833,18 @@ class MonitorsUpdater(PuavoWidget):
     self.send_button.show()
     self.applet.menu.append(self.send_button)
 
+    self.reset_button = Gtk.MenuItem(label=_tr('Re-run display settings'))
+    self.reset_button.connect('activate', self.reset_displays)
+    self.reset_button.show()
+    self.applet.menu.append(self.reset_button)
+
+
     return True
 
+  def reset_displays(self, widget):
+    cmd = [ '/usr/lib/puavo-ltsp-client/run-xrandr' ]
+    subprocess.Popen(cmd, close_fds=True)
+    return
 
   def send_display_configuration(self, widget):
     cmd = [ '/usr/bin/puavo-send-monitors-xml' ]

--- a/parts/desktop-applet/puavo-desktop-applet
+++ b/parts/desktop-applet/puavo-desktop-applet
@@ -833,10 +833,11 @@ class MonitorsUpdater(PuavoWidget):
     self.send_button.show()
     self.applet.menu.append(self.send_button)
 
-    self.reset_button = Gtk.MenuItem(label=_tr('Re-run display settings'))
-    self.reset_button.connect('activate', self.reset_displays)
-    self.reset_button.show()
-    self.applet.menu.append(self.reset_button)
+    if (len(puavoconf_get('puavo.xrandr.args'))>2): #xrandr args other than [] exist
+      self.reset_button = Gtk.MenuItem(label=_tr('Re-initialize display settings'))
+      self.reset_button.connect('activate', self.reset_displays)
+      self.reset_button.show()
+      self.applet.menu.append(self.reset_button)
 
 
     return True


### PR DESCRIPTION
As discussed, many of the problems with multiple displays, various beamers, adapters etc. are hard to fix well, but seem to be possible to fix temporarily just by running the xrandr settings in an online system (instead of during startup). Initial button for an user to be able to do just that. RFC.