### PR TITLE
Update 'puavo-disk-clone' and 'puavo-test-hardware'

### DIFF
--- a/parts/ltsp/client/puavo-test-hardware
+++ b/parts/ltsp/client/puavo-test-hardware
@@ -378,7 +378,7 @@ while true; do
                microphone 'Test microphone' \
                mouse      'Test mouse/mice' \
                wifi       'Test wireless networking' \
-	       speakers   'Test speakers' \
+               speakers   'Test speakers' \
                quit       'Exit tests') || true
 
   case "$response" in

--- a/parts/ltsp/client/puavo-test-hardware
+++ b/parts/ltsp/client/puavo-test-hardware
@@ -377,8 +377,8 @@ while true; do
                keyboard   'Test keyboard' \
                microphone 'Test microphone' \
                mouse      'Test mouse/mice' \
-               speakers   'Test speakers' \
                wifi       'Test wireless networking' \
+	       speakers   'Test speakers' \
                quit       'Exit tests') || true
 
   case "$response" in
@@ -386,9 +386,9 @@ while true; do
     disks)      mainmenu_default_item=disks;      test_disks      || true ;;
     keyboard)   mainmenu_default_item=microphone; test_keyboard   || true ;;
     microphone) mainmenu_default_item=mouse;      test_microphone || true ;;
-    mouse)      mainmenu_default_item=speakers;   test_mouse      || true ;;
-    speakers)   mainmenu_default_item=wifi;       test_speakers   || true ;;
-    wifi)       mainmenu_default_item=quit;       test_wifi       || true ;;
+    mouse)      mainmenu_default_item=wifi;       test_mouse      || true ;;
+    wifi)       mainmenu_default_item=speakers;   test_wifi       || true ;;
+    speakers)   mainmenu_default_item=quit;       test_speakers   || true ;;
     quit|'')    break ;;
     *)          echo 'Unknown option' >&2 ;;
   esac

--- a/parts/ltsp/puavo-install/puavo-disk-clone
+++ b/parts/ltsp/puavo-install/puavo-disk-clone
@@ -73,7 +73,7 @@ case "$mode" in
       image_name="$answer"
     fi
 
-    ocs-sr -q2 -j2 -z1p -i 4096 -fsck-src-part -scs -p true \
+    ocs-sr -rm-win-swap-hib -q2 -j2 -z1p -i 4096 -fsck-src-part -scs -p true \
            savedisk "$image_name" "$source_disk"
     ;;
   *)


### PR DESCRIPTION
- Savedisk will now run with flag --rm-win-swap-hib to make sure no swapfile / hibernation file from windows partition is included in the disk clone.
- Changed the order of speaker test and wireless test based on feedback. The test flow should now be a bit more "flush".

It was also intended to change the savedisk compression algorithm from gzip to something else (likely xz), but decided to postpone it as xz has yet to get proper multi-threading support for decompression. Switching to bzip2 was also looked into, but seeing it offered quite little improvement over gzip, I decided not to. (600MB smaller file size with bzip2 for a 21GB file vs. gzip.)

Will probably return to the compression side of things at some point when xz has better support for multi-threaded decompression.