### PR TITLE
Fix mic and speakertest on some older devices.

### DIFF
--- a/parts/ltsp/client/puavo-test-hardware
+++ b/parts/ltsp/client/puavo-test-hardware
@@ -287,14 +287,14 @@ test_mouse() {
 
 test_microphone() {
   local alsadev
+  clear
   product_name=`cat /sys/class/dmi/id/product_name`
   case "$product_name" in
-    "HP EliteBook 840 G1" )
+    "HP EliteBook 820 G1" | "HP EliteBook 840 G1" | "HP EliteBook 820 G2" | "HP EliteBook 840 G2" )
       alsadev='hw:1,0' ;;
     *)
       alsadev='hw:0,0' ;;
   esac
-  clear
   echo "Using ALSA device ${alsadev} for recording..."
   echo
 
@@ -309,21 +309,27 @@ test_microphone() {
 test_speakers() {
   local speaker_test_status
 
-  speaker_test_status=0
-
   clear
+  speaker_test_status=0
+  product_name=`cat /sys/class/dmi/id/product_name`
+  case "$product_name" in
+    "HP EliteBook 820 G1" | "HP EliteBook 840 G1" | "HP EliteBook 820 G2" | "HP EliteBook 840 G2" )
+      alsadev='hw:1,0'
+      speaker-test --device="${alsadev}" -t wav  -c 2 -l 3 || speaker_test_status=1
+      speaker-test --device="${alsadev}" -t pink -c 2 -l 1 || speaker_test_status=1 ;;
+    *)
+      alsadev='default'
+      speaker-test --device="${alsadev}" -t wav  -c 2 -l 3 || speaker_test_status=1
+      speaker-test --device="${alsadev}" -t pink -c 2 -l 1 || speaker_test_status=1
 
-  speaker-test -t wav  -c 2 -l 3 || speaker_test_status=1
-  speaker-test -t pink -c 2 -l 1 || speaker_test_status=1
-
-  # XXX This uses wav files that might no longer exist after
-  # XXX Scratch or Solfege is updated.
-  aplay /usr/share/scratch/Media/Sounds/Vocals/Singer1.wav \
+      # XXX This uses wav files that might no longer exist after
+      # XXX Scratch or Solfege is updated.
+      aplay /usr/share/scratch/Media/Sounds/Vocals/Singer1.wav \
         /usr/share/scratch/Media/Sounds/Electronic/ComputerBeeps1.wav \
         /usr/share/scratch/Media/Sounds/Human/Laugh-female.wav \
         /usr/share/solfege/exercises/standard/lesson-files/share/fanfare.wav \
-    || speaker_test_status=1
-
+    || speaker_test_status=1;;
+  esac
   sleep 2
 }
 

--- a/parts/ltsp/client/puavo-test-hardware
+++ b/parts/ltsp/client/puavo-test-hardware
@@ -325,10 +325,10 @@ test_speakers() {
       # XXX This uses wav files that might no longer exist after
       # XXX Scratch or Solfege is updated.
       aplay /usr/share/scratch/Media/Sounds/Vocals/Singer1.wav \
-        /usr/share/scratch/Media/Sounds/Electronic/ComputerBeeps1.wav \
-        /usr/share/scratch/Media/Sounds/Human/Laugh-female.wav \
-        /usr/share/solfege/exercises/standard/lesson-files/share/fanfare.wav \
-    || speaker_test_status=1;;
+            /usr/share/scratch/Media/Sounds/Electronic/ComputerBeeps1.wav \
+            /usr/share/scratch/Media/Sounds/Human/Laugh-female.wav \
+            /usr/share/solfege/exercises/standard/lesson-files/share/fanfare.wav \
+        || speaker_test_status=1;;
   esac
   sleep 2
 }

--- a/parts/ltsp/client/puavo-test-hardware
+++ b/parts/ltsp/client/puavo-test-hardware
@@ -287,9 +287,13 @@ test_mouse() {
 
 test_microphone() {
   local alsadev
-
-  alsadev='hw:0,0'
-
+  product_name=`cat /sys/class/dmi/id/product_name`
+  case "$product_name" in
+    "HP EliteBook 840 G1" )
+      alsadev='hw:1,0' ;;
+    *)
+      alsadev='hw:0,0' ;;
+  esac
   clear
   echo "Using ALSA device ${alsadev} for recording..."
   echo


### PR DESCRIPTION
Noticed microphone and speakertest doesn't work on a HP EliteBook 840 G1. For the microphone test, problem seems to be caused by the hardcoded input device 'hw:0,0'.

Added a case statement to microphone and speakertest. Microphone test now works without problems, even on older devices.
This also fixes speakertest on G1/G2 as much as it seems possible (more on that below).

'aplay' does not want to work at all if you specifically choose a device with '--device' flag. It works out-of-the-box on devices other than G1/G2 as long as you do not force a device to use by issuing the flag above.

Good enough for now. At least we can now test audio input/output on older devices without breaking the compatibility with newer ones.