### PR TITLE
Replace case statement with a device selection of 'plughw:CARD=PCH'.

### DIFF
--- a/parts/ers/po/fi/puavo-ers-applet.po
+++ b/parts/ers/po/fi/puavo-ers-applet.po
@@ -44,3 +44,15 @@ msgstr ""
 "Koeautomaation apurimekanismia ei löytynyt,"
 " ole hyvä ja asenna se virtuaalipalvelimeen"
 " (suorita virtuaalipalvelimessa /media/usb1/ktpapu-asennin)."
+
+msgid "Exam sync is active"
+msgstr "Kokeiden haku on päällä"
+
+msgid "Exam sync is NOT active"
+msgstr "Kokeiden haku EI ole päällä"
+
+msgid "Enable exam sync"
+msgstr "Kytke kokeiden haku päälle"
+
+msgid "Disable exam sync"
+msgstr "Kytke kokeiden haku pois päältä"

--- a/parts/ers/po/fi/puavo-ers-applet.po
+++ b/parts/ers/po/fi/puavo-ers-applet.po
@@ -21,6 +21,9 @@ msgstr "Purkukoodit"
 msgid "No current exams"
 msgstr "Ei kokeita"
 
+msgid "No exams due to error"
+msgstr "Ei kokeita virheen takia"
+
 msgid "Exam session automation is active"
 msgstr "Koesessioiden automaatio on toiminnassa"
 

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -151,15 +151,21 @@ class PuavoExamServer (threading.Thread):
       raise Exception('message does not have a type')
     if type(msg['type']) != str:
       raise Exception('message type is not a string')
+    if not 'id' in msg:
+      raise Exception('message does not have a id')
+    if type(msg['id']) != int:
+      raise Exception('message id is not a integer')
 
     if msg['type'] == 'pong':
       return
 
-    if msg['type'] == 'change_exam_session_access_code':
+    self.send({ 'type': 'ack', 'id': msg['id'] })
+
+    if msg['type'] == 'change_access_code':
       syslog.syslog(syslog.LOG_INFO,
-                    'received change exam session access code message from' \
-                      + ' exams controller')
+                    'received change access code message from exams controller')
       self.exam_scheduler.request_keycode_change()
+      # XXX should return some ack message?
       return
 
     if msg['type'] == 'refresh_exams':
@@ -1310,6 +1316,8 @@ class PuavoErsExamScheduler (threading.Thread):
     self.finish_time               = self.end_of_today()
     self.has_started               = False
 
+    self.keycode_change_request_lock = threading.Lock()
+
 
   def change_keycode(self):
     return self.server_cmd('change-keycode')
@@ -1324,7 +1332,8 @@ class PuavoErsExamScheduler (threading.Thread):
 
 
   def request_keycode_change(self):
-    self.do_keycode_change_request = True
+    with self.keycode_change_request_lock:
+      self.do_keycode_change_request = True
 
 
   def load_empty_examset(self):
@@ -1531,14 +1540,19 @@ class PuavoErsExamScheduler (threading.Thread):
         self.finish_time = now
 
 
-  def schedule_exams(self, current_exams_set):
-    if self.has_started and self.do_keycode_change_request:
+  def handle_keycode_change_request(self):
+    with self.keycode_change_request_lock:
       try:
-        syslog.syslog(syslog.LOG_INFO, 'handling keycode change request')
-        self.change_keycode()
-        self.do_keycode_change_request = False
+        if self.has_started and self.do_keycode_change_request:
+          syslog.syslog(syslog.LOG_INFO, 'handling keycode change request')
+          self.change_keycode()
+          self.do_keycode_change_request = False
       except Exception as e:
         syslog.syslog(syslog.LOG_ERR, 'could not change keycode: %s' % e)
+
+
+  def schedule_exams(self, current_exams_set):
+    self.handle_keycode_change_request()
 
     status = (self.get_status())['status']
     self.has_started = (status['hasStarted'] == True)

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -100,7 +100,8 @@ class PuavoExamServer (threading.Thread):
     self.ws = None
 
 
-  def add_other_threads(self, exam_sync):
+  def add_other_threads(self, exam_scheduler, exam_sync):
+    self.exam_scheduler = exam_scheduler
     self.exam_sync = exam_sync
 
 
@@ -155,10 +156,10 @@ class PuavoExamServer (threading.Thread):
       return
 
     if msg['type'] == 'change_exam_session_access_code':
-      # XXX don't just log, do something!
       syslog.syslog(syslog.LOG_INFO,
                     'received change exam session access code message from' \
                       + ' exams controller')
+      self.exam_scheduler.request_keycode_change()
       return
 
     if msg['type'] == 'refresh_exams':
@@ -312,7 +313,7 @@ class PuavoErsApplet:
     self.exam_server_helper = PuavoErsServerHelper()
     self.exam_scheduler = PuavoErsExamScheduler(self.exam_control)
 
-    self.exam_server.add_other_threads(self.exam_sync)
+    self.exam_server.add_other_threads(self.exam_scheduler, self.exam_sync)
 
     self.exam_server.start()
     self.exam_sync.start()
@@ -882,9 +883,9 @@ class PuavoErsExamControl (threading.Thread):
 
     self.exam_server = exam_server
 
+    self.local_status_updated = False
     self.send_status_update_lock = threading.Condition()
     self.status = None
-    self.local_status_updated = False
 
 
   def run(self):
@@ -938,6 +939,8 @@ class PuavoErsExamControl (threading.Thread):
       self.send_status_update_lock.notify()
 
     self.send_status_update_lock.release()
+
+    # self.save_status_to_disk()
 
 
   def save_status_to_disk(self):
@@ -1299,11 +1302,17 @@ class PuavoErsExamScheduler (threading.Thread):
   def __init__(self, exam_control):
     threading.Thread.__init__(self)
 
-    self.answers_stored_time    = None
-    self.exam_control           = exam_control
-    self.exam_scheduler_enabled = False
-    self.finished_and_students  = None
-    self.finish_time            = self.end_of_today()
+    self.answers_stored_time       = None
+    self.do_keycode_change_request = False
+    self.exam_control              = exam_control
+    self.exam_scheduler_enabled    = False
+    self.finished_and_students     = None
+    self.finish_time               = self.end_of_today()
+    self.has_started               = False
+
+
+  def change_keycode(self):
+    return self.server_cmd('change-keycode')
 
 
   def get_exams(self):
@@ -1312,6 +1321,10 @@ class PuavoErsExamScheduler (threading.Thread):
 
   def get_status(self):
     return self.server_cmd('get-status')
+
+
+  def request_keycode_change(self):
+    self.do_keycode_change_request = True
 
 
   def load_empty_examset(self):
@@ -1519,9 +1532,16 @@ class PuavoErsExamScheduler (threading.Thread):
 
 
   def schedule_exams(self, current_exams_set):
-    status_response = self.get_status()
-    status = status_response['status']
-    has_started = (status['hasStarted'] == True)
+    if self.has_started and self.do_keycode_change_request:
+      try:
+        syslog.syslog(syslog.LOG_INFO, 'handling keycode change request')
+        self.change_keycode()
+        self.do_keycode_change_request = False
+      except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, 'could not change keycode: %s' % e)
+
+    status = (self.get_status())['status']
+    self.has_started = (status['hasStarted'] == True)
 
     self.exam_control.update_status(status)
 
@@ -1539,13 +1559,13 @@ class PuavoErsExamScheduler (threading.Thread):
     if exams_finished:
       self.maybe_store_answers(currently_loaded_exams, status)
 
-    if has_started and not exams_finished:
+    if self.has_started and not exams_finished:
       syslog.syslog(syslog.LOG_INFO,
                     'examinations are in progress, not loading any exams')
       return
 
     if len(current_exams_set.exams) == 0:
-      if has_started:
+      if self.has_started:
         msg = 'exams ongoing but should not be according to schedule,' \
                  + ' resetting server state'
         syslog.syslog(syslog.LOG_INFO, msg)
@@ -1567,13 +1587,13 @@ class PuavoErsExamScheduler (threading.Thread):
         syslog.syslog(syslog.LOG_INFO, 'loading exams')
         self.load_exams()
         self.finish_time = current_exams_set.latest_end_time
-        has_started = False
+        self.has_started = False
     except CurrentZipNotReady as e:
       syslog.syslog(syslog.LOG_INFO,
                     'exam scheduler is waiting for zip file to be ready')
       return
 
-    if not has_started \
+    if not self.has_started \
       and current_exams_set.earliest_start_time <= datetime.datetime.now():
         syslog.syslog(syslog.LOG_NOTICE, 'starting up exams')
         self.start_loaded_exams()

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -245,9 +245,10 @@ class PuavoErsApplet:
     self.menu.show_all()
 
     self.exam_server = PuavoExamServer()
-    self.exam_sync = PuavoErsExamSync(self.exam_server, self.exam_sync_active)
-    self.exam_control = PuavoErsExamControl(self.exam_server)
     self.exam_sorter = PuavoErsExamSorter(self.exam_sync_active)
+    self.exam_sync = PuavoErsExamSync(self.exam_server, self.exam_sorter,
+                                      self.exam_sync_active)
+    self.exam_control = PuavoErsExamControl(self.exam_server)
     self.exam_server_helper = PuavoErsServerHelper()
     self.exam_scheduler = PuavoErsExamScheduler(self.exam_control)
 
@@ -689,17 +690,17 @@ class DecryptCodesWindow:
 
 
 class PuavoErsExamSync (threading.Thread):
-  def __init__(self, exam_server, is_active):
+  def __init__(self, exam_server, exam_sorter, is_active):
     threading.Thread.__init__(self)
 
     self.exam_server = exam_server
+    self.exam_sorter = exam_sorter
     self.exam_sync_enabled = is_active
     self.do_exam_sync = True
     self.sync_exams_lock = threading.Condition()
 
 
   def run(self):
-     is_enabled = None
      self.sync_exams_lock.acquire()
 
      while True:
@@ -711,9 +712,9 @@ class PuavoErsExamSync (threading.Thread):
 
          if self.exam_sync_enabled:
            self.sync_exams()
-         elif is_enabled != self.exam_sync_enabled:
+         else:
            syslog.syslog(syslog.LOG_INFO, 'exam sync has been disabled')
-           is_enabled = self.exam_sync_enabled
+
          self.do_exam_sync = False
 
        except Exception as e:
@@ -739,6 +740,8 @@ class PuavoErsExamSync (threading.Thread):
     exams_json = response.content.decode('utf-8')
     self.update_exams_json_on_disk(exams_json)
 
+    fatal_errors = False
+
     exam_name_list = []
     for exam in json.loads(exams_json):
       try:
@@ -755,6 +758,7 @@ class PuavoErsExamSync (threading.Thread):
         exam_name_list.append(exam_file_name)
       except Exception as e:
         syslog.syslog(syslog.LOG_ERR, 'error in syncing one exam: %s' % e)
+        fatal_errors = True
 
     # clean up old exams that no longer belong to exams subdirectories
     for exam_path in glob.glob( os.path.join(EXAMS_DIR, 'exam_*.me[bx]') ):
@@ -763,6 +767,11 @@ class PuavoErsExamSync (threading.Thread):
         # it has already been archived and we can delete it here.
         if os.stat(exam_path).st_nlink > 1:
           rm_f(exam_path)
+
+    self.exam_sorter.trigger_sort_exams()
+
+    if fatal_errors:
+      raise Exception('there were errors when syncing exams')
 
 
   def update_exams_json_on_disk(self, exams_json):
@@ -942,18 +951,26 @@ class PuavoErsExamSorter (threading.Thread):
     self.previous_current_exams = None
     self.previous_todays_exams  = None
 
+    self.do_sort_exams = True
+    self.sort_exams_lock = threading.Condition()
+
 
   def run(self):
-    is_enabled = None
+    self.sort_exams_lock.acquire()
 
     while True:
       try:
+         # we do not check with while, because this can be run periodically
+        if not self.do_sort_exams:
+          self.sort_exams_lock.wait(timeout=600)
+
         if self.exam_sorter_enabled:
           with exam_scheduler_lock:
             self.sort_exams_to_dirs()
-        elif is_enabled != self.exam_sorter_enabled:
+        else:
           syslog.syslog(syslog.LOG_INFO, 'exam sorter has been disabled')
-          is_enabled = self.exam_sorter_enabled
+
+        self.do_sort_exams = False
 
       except Exception as e:
         syslog.syslog(syslog.LOG_ERR, 'error when sorting exams: %s' % e)
@@ -961,8 +978,17 @@ class PuavoErsExamSorter (threading.Thread):
       time.sleep(10)
 
 
+  def trigger_sort_exams(self):
+    self.sort_exams_lock.acquire()
+    self.do_sort_exams = True
+    self.sort_exams_lock.notify()
+    self.sort_exams_lock.release()
+
+
   def sort_exams_to_dirs(self):
     global current_exams_set
+
+    syslog.syslog(syslog.LOG_INFO, 'sorting exams in filesystem')
 
     self.current_day  = datetime.date.today()
     self.current_time = datetime.datetime.now()
@@ -983,6 +1009,8 @@ class PuavoErsExamSorter (threading.Thread):
     upcoming_exams_filenames = []
 
     decrypt_codes_list = []
+
+    fatal_errors = False
 
     for exam in all_exams:
       try:
@@ -1015,6 +1043,7 @@ class PuavoErsExamSorter (threading.Thread):
 
       except Exception as e:
         syslog.syslog(syslog.LOG_ERR, 'could not handle an exam: %s' % e)
+        fatal_errors = True
 
     current_exams_set = ExamSet(current_exams)
     current_exams_set.add_overlapping_exams(todays_exams, self.current_time)
@@ -1033,6 +1062,9 @@ class PuavoErsExamSorter (threading.Thread):
 
     self.zip_exams(current_exams_filenames, todays_exams_filenames,
         decrypt_codes_list)
+
+    if fatal_errors:
+      raise Exception('there were some problems when sorting exams')
 
 
   def cleanup_exams(self, linkdir, exam_filenames):
@@ -1300,7 +1332,7 @@ class PuavoErsExamScheduler (threading.Thread):
       except ExamSchedulerNotActive as e:
         if is_enabled != self.exam_scheduler_enabled:
           syslog.syslog(syslog.LOG_INFO, 'exam scheduler has been disabled')
-          is_enabled = self.exam_scheduler_enabled
+          is_enabled = False
 
       except Exception as e:
         comm_ok = False
@@ -1497,7 +1529,6 @@ class PuavoErsExamScheduler (threading.Thread):
 
 
   def try_server_cmd(self, cmd):
-    syslog.syslog(syslog.LOG_INFO, 'sending command to exam server: "%s"' % cmd)
     output_paths = [ self.CMD_IN_PROGRESS_PATH, self.CMD_RESULT_PATH,
                      self.DEBUG_OUTPUT_PATH, self.EXAMS_PATH, self.OUTPUT_PATH,
                      self.STATS_PATH ]
@@ -1512,6 +1543,9 @@ class PuavoErsExamScheduler (threading.Thread):
 
       with open(self.CMD_IN_PROGRESS_PATH, 'w') as f:
         pass
+
+      syslog.syslog(syslog.LOG_INFO,
+                    'sending command to exam server: "%s"' % cmd)
 
       with open(self.CMD_PATH, 'w') as f:
         f.write("%s\n" % cmd)

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -78,6 +78,7 @@ class ExamSchedulerNotActive(Exception):
 class PuavoErsApplet:
   NAKSU_ORIGIN_PATH = '/opt/abitti-naksu/naksu'
   PUAVO_ERS_DIR = os.path.join(os.environ['HOME'], '.puavo', 'puavo-ers')
+  CONFIG_PATH = os.path.join(PUAVO_ERS_DIR, 'config.json')
   NAKSU_BIN_PATH = os.path.join(PUAVO_ERS_DIR, 'naksu')
   SERVER_VERSION_PATH  = os.path.join(COMM_DIR, '.server_version')
 
@@ -95,6 +96,8 @@ class PuavoErsApplet:
 
     os.makedirs(self.PUAVO_ERS_DIR, exist_ok=True)
 
+    self.load_configuration()
+
     self.menu = Gtk.Menu()
     self.old_exams = None
     self.menuitems = []
@@ -104,10 +107,10 @@ class PuavoErsApplet:
 
     self.menu.show_all()
 
-    self.exam_sync = PuavoErsExamSync()
+    self.exam_sync = PuavoErsExamSync(self.exam_sync_active)
     self.exam_sync.start()
 
-    self.exam_sorter = PuavoErsExamSorter()
+    self.exam_sorter = PuavoErsExamSorter(self.exam_sync_active)
     self.exam_sorter.start()
 
     self.exams_server_helper = PuavoErsServerHelper()
@@ -123,10 +126,61 @@ class PuavoErsApplet:
       shutil.copy2(self.NAKSU_ORIGIN_PATH, self.NAKSU_BIN_PATH)
 
 
+  def load_configuration(self):
+    self.automation_active = None
+    self.exam_sync_active = None
+
+    error = None
+    try:
+      with open(self.CONFIG_PATH) as file:
+        config = json.load(file)
+      if 'automation_active' in config:
+        self.automation_active = config['automation_active']
+      if 'exam_sync_active' in config:
+        self.exam_sync_active = config['exam_sync_active']
+    except OSError as e:
+      if e.errno != errno.ENOENT:
+        error = e
+    except Exception as e:
+      error = e
+
+    if error:
+      syslog.syslog(syslog.LOG_ERR, 'could not read configuration: %s' % error)
+
+    create_defaults = False
+
+    if self.automation_active == None:
+      create_defaults = True
+      self.automation_active = True
+    if self.exam_sync_active == None:
+      create_defaults = True
+      self.exam_sync_active = True
+
+    if create_defaults:
+      self.save_configuration()
+
+
+  def save_configuration(self):
+    try:
+      data = {
+        'automation_active': self.automation_active,
+        'exam_sync_active':  self.exam_sync_active,
+      }
+      tmpfile = '%s.tmp' % self.CONFIG_PATH
+      with open(tmpfile, 'w') as f:
+        json.dump(data, f)
+      os.rename(tmpfile, self.CONFIG_PATH)
+    except Exception as e:
+      syslog.syslog(syslog.LOG_ERR, 'could not save configuration: %s' % e)
+
+
   def main(self):
     self.run_naksu()
     GLib.timeout_add_seconds(1, self.update_decrypt_codes)
-    self.enable_exam_scheduler()
+
+    if self.automation_active and self.exam_sync_active:
+      self.enable_exam_scheduler()
+
     Gtk.main()
 
 
@@ -231,7 +285,7 @@ class PuavoErsApplet:
 
       labels_and_exams_list.append({ 'exam': exam, 'label': label })
 
-    self.make_automation_control_button()
+    self.make_automation_control_buttons()
 
     if len(labels_and_exams_list) > 24:
       # we can not fit too many labels on the applet menu,
@@ -267,7 +321,31 @@ class PuavoErsApplet:
       self.menu.append(instructions)
 
 
-  def make_automation_control_button(self):
+  def make_automation_control_buttons(self):
+    if self.exam_sync_active:
+      sync_info_button = Gtk.MenuItem(label=_tr('Exam sync is active'))
+      sync_info_button.set_sensitive(False)
+      sync_control_button = Gtk.MenuItem(label=_tr('Disable exam sync'))
+      sync_control_button.connect('activate', self.disable_exam_sync)
+    else:
+      sync_info_button = Gtk.MenuItem(label=_tr('Exam sync is NOT active'))
+      sync_info_button.set_sensitive(False)
+      sync_control_button = Gtk.MenuItem(label=_tr('Enable exam sync'))
+      sync_control_button.connect('activate', self.enable_exam_sync)
+
+    sync_info_button.show()
+    self.menu.append(sync_info_button)
+    self.menuitems.append(sync_info_button)
+
+    sync_control_button.show()
+    self.menu.append(sync_control_button)
+    self.menuitems.append(sync_control_button)
+
+    separator = Gtk.SeparatorMenuItem()
+    separator.show()
+    self.menuitems.append(separator)
+    self.menu.append(separator)
+
     if self.exams_scheduler.exam_scheduler_enabled:
       auto_info_button = Gtk.MenuItem(
         label=_tr('Exam session automation is active'))
@@ -286,6 +364,7 @@ class PuavoErsApplet:
     self.menuitems.append(auto_info_button)
 
     auto_control_button.show()
+    auto_control_button.set_sensitive(self.exam_sync_active)
     self.menu.append(auto_control_button)
     self.menuitems.append(auto_control_button)
 
@@ -295,14 +374,53 @@ class PuavoErsApplet:
     self.menu.append(separator)
 
 
+  def disable_exam_sync(self, widget=None):
+    self.exam_sync_active = False
+    self.save_configuration()
+
+    self.exam_sorter.exam_sorter_enabled = False
+    self.exam_sync.exam_sync_enabled     = False
+    self.update_decrypt_codes(True)
+
+    syslog.syslog(syslog.LOG_INFO, 'exam sync is now disabled')
+    Notify.Notification.new(_tr('Exam sync is NOT active')).show()
+
+    self.disable_exam_scheduler()
+
+
+  def enable_exam_sync(self, widget=None):
+    self.exam_sync_active = True
+    self.save_configuration()
+
+    self.exam_sorter.exam_sorter_enabled = True
+    self.exam_sync.exam_sync_enabled     = True
+    self.update_decrypt_codes(True)
+
+    syslog.syslog(syslog.LOG_INFO, 'exam sync is now enabled')
+    Notify.Notification.new(_tr('Exam sync is active')).show()
+
+    if self.automation_active:
+      self.enable_exam_scheduler()
+
+
   def disable_exam_scheduler(self, widget=None):
+    if widget:
+      self.automation_active = False
+      self.save_configuration()
+
+    is_enabled = self.exams_scheduler.exam_scheduler_enabled
     self.exams_scheduler.exam_scheduler_enabled = False
-    syslog.syslog(syslog.LOG_INFO, 'exam scheduler is now disabled')
-    Notify.Notification.new(_tr('Exam session automation is NOT active')).show()
+    if is_enabled != self.exams_scheduler.exam_scheduler_enabled:
+      syslog.syslog(syslog.LOG_INFO, 'exam scheduler is now disabled')
+      Notify.Notification.new(_tr('Exam session automation is NOT active')).show()
     self.update_decrypt_codes(True)
 
 
   def enable_exam_scheduler(self, widget=None):
+    if widget:
+      self.automation_active = True
+      self.save_configuration()
+
     current_automation_server_version = None
     current_server_version = None
 
@@ -347,10 +465,12 @@ class PuavoErsApplet:
       Notify.Notification.new(summary, body).show()
       return
 
-    Notify.Notification.new(_tr('Exam session automation is active')).show()
-
+    is_enabled = self.exams_scheduler.exam_scheduler_enabled
     self.exams_scheduler.exam_scheduler_enabled = True
-    syslog.syslog(syslog.LOG_INFO, 'exam scheduler is now enabled')
+    if is_enabled != self.exams_scheduler.exam_scheduler_enabled:
+      Notify.Notification.new(_tr('Exam session automation is active')).show()
+      syslog.syslog(syslog.LOG_INFO, 'exam scheduler is now enabled')
+
     self.update_decrypt_codes(True)
 
 
@@ -414,8 +534,10 @@ class DecryptCodesWindow:
 
 
 class PuavoErsExamSync (threading.Thread):
-  def __init__(self):
+  def __init__(self, is_active):
     threading.Thread.__init__(self)
+
+    self.exam_sync_enabled = is_active
 
     with open('/etc/puavo/domain') as f:
       self.domain = f.read().rstrip()
@@ -430,9 +552,16 @@ class PuavoErsExamSync (threading.Thread):
 
 
   def run(self):
+     is_enabled = None
+
      while True:
        try:
-         self.sync_exams()
+         if self.exam_sync_enabled:
+           self.sync_exams()
+         elif is_enabled != self.exam_sync_enabled:
+           syslog.syslog(syslog.LOG_INFO, 'exam sync has been disabled')
+           is_enabled = self.exam_sync_enabled
+
        except Exception as e:
          syslog.syslog(syslog.LOG_ERR, 'error when syncing exams: %s' % e)
 
@@ -592,18 +721,26 @@ class ExamSet:
 
 
 class PuavoErsExamSorter (threading.Thread):
-  def __init__(self):
+  def __init__(self, is_active):
     threading.Thread.__init__(self)
 
+    self.exam_sorter_enabled    = is_active
     self.previous_current_exams = None
     self.previous_todays_exams  = None
 
 
   def run(self):
+    is_enabled = None
+
     while True:
       try:
-        with exam_scheduler_lock:
-          self.sort_exams_to_dirs()
+        if self.exam_sorter_enabled:
+          with exam_scheduler_lock:
+            self.sort_exams_to_dirs()
+        elif is_enabled != self.exam_sorter_enabled:
+          syslog.syslog(syslog.LOG_INFO, 'exam sorter has been disabled')
+          is_enabled = self.exam_sorter_enabled
+
       except Exception as e:
         syslog.syslog(syslog.LOG_ERR, 'error when sorting exams: %s' % e)
 
@@ -921,6 +1058,7 @@ class PuavoErsExamScheduler (threading.Thread):
     global current_exams_set
 
     comm_ok = False
+    is_enabled = None
     old_comm_state = None
 
     while True:
@@ -948,7 +1086,9 @@ class PuavoErsExamScheduler (threading.Thread):
             self.schedule_exams(current_exams_set)
 
       except ExamSchedulerNotActive as e:
-        syslog.syslog(syslog.LOG_INFO, 'exam scheduler has been disabled')
+        if is_enabled != self.exam_scheduler_enabled:
+          syslog.syslog(syslog.LOG_INFO, 'exam scheduler has been disabled')
+          is_enabled = self.exam_scheduler_enabled
 
       except Exception as e:
         comm_ok = False

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -158,9 +158,9 @@ class PuavoExamServer (threading.Thread):
 
     self.send({ 'type': 'ack', 'id': msg['id'] })
 
-    if msg['type'] == 'change_access_code':
+    if msg['type'] == 'change_keycode':
       syslog.syslog(syslog.LOG_INFO,
-                    'received change access code message from exams controller')
+                    'received change keycode message from exams controller')
       self.exam_scheduler.request_keycode_change()
       return
 

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -745,8 +745,8 @@ class PuavoErsExamSorter (threading.Thread):
     try:
       if not os.path.exists(current_zip_path) \
         or current_exams_filenames != self.previous_current_exams:
-          self.zip_an_exam_set(current_exams_filenames, current_zip_path)
-          self.update_decrypt_codes_in_file(decrypt_codes_list)
+          self.zip_an_exam_set(current_exams_filenames, current_zip_path,
+                               decrypt_codes_list)
           self.previous_current_exams = current_exams_filenames
     except Exception as e:
       syslog.syslog(syslog.LOG_ERR,
@@ -767,9 +767,12 @@ class PuavoErsExamSorter (threading.Thread):
         rm_f(zipfile)
 
 
-  def zip_an_exam_set(self, exams, zip_path):
-    rm_f(zip_path)
+  def zip_an_exam_set(self, exams, zip_path, decrypt_codes_list=None):
     if len(exams) == 0:
+      if os.path.exists(zip_path):
+        rm_f(zip_path)
+        if decrypt_codes_list != None:
+          self.update_decrypt_codes_in_file(decrypt_codes_list)
       return
 
     exam_paths = [ os.path.join(KTP_JAKO_DIR, p) for p in exams ]
@@ -782,6 +785,9 @@ class PuavoErsExamSorter (threading.Thread):
       for filename in unique_exam_paths:
         zipObj.write(filename, os.path.basename(filename))
     os.rename(tmpfile, zip_path)
+
+    if decrypt_codes_list != None:
+     self.update_decrypt_codes_in_file(decrypt_codes_list)
 
 
   def update_decrypt_codes_in_file(self, decrypt_codes_list):

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -917,17 +917,20 @@ class PuavoErsExamControl (threading.Thread):
 
 
   def send_status(self, status):
+    syslog.syslog(syslog.LOG_INFO, 'sending status update to server')
+
     response = self.exam_server.post('/v1/servers/status_update', status)
     if not response or response.status_code != requests.codes.ok:
       raise Exception('could not send status update to server')
 
-    syslog.syslog(syslog.LOG_INFO, 'sending status update to server')
 
-    self.status = status
-
-
-  def update_status(self, new_status):
+  def update_status(self, new_abitti_status, monitoring_passphrase):
     self.send_status_update_lock.acquire()
+
+    new_status = {
+      'monitoring_passphrase': monitoring_passphrase,
+      'status':                new_abitti_status,
+    }
 
     if self.status != new_status:
       self.status = new_status
@@ -937,21 +940,6 @@ class PuavoErsExamControl (threading.Thread):
       self.send_status_update_lock.notify()
 
     self.send_status_update_lock.release()
-
-    # self.save_status_to_disk()
-
-
-  def save_status_to_disk(self):
-    # This method has no other purpose except to help with
-    # monitoring/debugging.  Perhaps this should be removed?
-    try:
-      tmpfile = '%s.tmp' % self.STATUS_PATH
-      with open(tmpfile, 'w') as f:
-        json.dump(self.status, f)
-      os.rename(tmpfile, self.STATUS_PATH)
-    except Exception as e:
-      syslog.syslog(syslog.LOG_ERR,
-                    'error when saving status to disk: %s' % e)
 
 
 class ExamSet:
@@ -1307,6 +1295,7 @@ class PuavoErsExamScheduler (threading.Thread):
     self.finished_and_students     = None
     self.finish_time               = self.end_of_today()
     self.has_started               = False
+    self.monitoring_passphrase     = None
 
     self.keycode_change_request_lock = threading.Lock()
 
@@ -1317,6 +1306,10 @@ class PuavoErsExamScheduler (threading.Thread):
 
   def get_exams(self):
     return self.server_cmd('get-exam')
+
+
+  def get_passphrase(self):
+    return self.server_cmd('get-passphrase')
 
 
   def get_status(self):
@@ -1389,6 +1382,8 @@ class PuavoErsExamScheduler (threading.Thread):
     while True:
       try:
         if not comm_ok:
+          self.monitoring_passphrase = None
+
           output = self.ping()
           if output['error'] == False:
             comm_ok = True
@@ -1410,7 +1405,7 @@ class PuavoErsExamScheduler (threading.Thread):
       except ExamSchedulerNotActive as e:
         if is_enabled != self.exam_scheduler_enabled:
           syslog.syslog(syslog.LOG_INFO, 'exam scheduler has been disabled')
-          is_enabled = False
+        is_enabled = False
 
       except Exception as e:
         comm_ok = False
@@ -1543,13 +1538,39 @@ class PuavoErsExamScheduler (threading.Thread):
         syslog.syslog(syslog.LOG_ERR, 'could not change keycode: %s' % e)
 
 
+  def update_monitoring_passphrase(self):
+    # Assume that this does not change except when the virtual exam server
+    # has rebooted and we must have lost communication to it as that has
+    # happened.
+    if self.monitoring_passphrase:
+      return
+
+    try:
+      answer = self.get_passphrase()
+      if not 'get-passphrase' in answer:
+        raise Exception('no get-passphrase key')
+      if type(answer['get-passphrase']) != dict:
+        raise Exception('get-passphrase value is not a dict')
+      if not 'passphrase' in answer['get-passphrase']:
+        raise Exception('no passphrase key')
+      if type(answer['get-passphrase']['passphrase']) != str:
+        raise Exception('passphrase key is not a string')
+      self.monitoring_passphrase = answer['get-passphrase']['passphrase']
+      syslog.syslog(syslog.LOG_INFO,
+        "looked up monitoring passphrase: '%s'" % self.monitoring_passphrase)
+    except Exception as e:
+      syslog.syslog(syslog.LOG_ERR,
+                    'could not get monitoring passphrase: %s' % e)
+
+
   def schedule_exams(self, current_exams_set):
     self.handle_keycode_change_request()
 
     status = (self.get_status())['status']
     self.has_started = (status['hasStarted'] == True)
 
-    self.exam_control.update_status(status)
+    self.update_monitoring_passphrase()
+    self.exam_control.update_status(status, self.monitoring_passphrase)
 
     if not self.exam_scheduler_enabled:
       raise ExamSchedulerNotActive

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import base64
 import copy
 import datetime
 import errno
@@ -21,6 +22,8 @@ import sys
 import syslog
 import threading
 import time
+import urllib
+import websocket
 import zipfile
 
 gi.require_version('AppIndicator3', '0.1')
@@ -77,8 +80,10 @@ class ExamSchedulerNotActive(Exception):
   pass
 
 
-class PuavoExamServer:
+class PuavoExamServer (threading.Thread):
   def __init__(self):
+    threading.Thread.__init__(self)
+
     self.exam_server_name = puavoconf_get('puavo.abitti.exam_server')
 
     with open('/etc/puavo/domain') as f:
@@ -91,6 +96,57 @@ class PuavoExamServer:
       self.ldap_dn = f.read().rstrip()
     with open('/etc/puavo/ldap/password') as f:
       self.ldap_password = f.read().rstrip()
+
+    self.ws = None
+
+
+  def run(self):
+     while True:
+       try:
+         self.ws = self.open_connection()
+
+         # XXX we should fetch exam index in case we are here
+         # XXX (those might have been updated when we have not had a
+         # XXX connection and we would not have gotten a notification about it)
+         # XXX time is also another factor... received data changes as time
+         # XXX goes past.... so the exam fetch condition variable should
+         # XXX have a timeout of one hour or something?
+
+         while self.ws:
+           self.handle_message( self.ws.recv() )
+       except Exception as e:
+         syslog.syslog(syslog.LOG_ERR, 'error with server connection: %s' % e)
+       finally:
+         if self.ws:
+           self.ws.close()
+           self.ws = None
+
+       time.sleep(10)
+
+
+  def handle_message(self, msg):
+    # XXX
+    syslog.syslog(syslog.LOG_INFO, 'we got a message: %s' % msg)
+
+
+  def open_connection(self):
+    ws = websocket.WebSocket()
+
+    credentials = '%s:%s' % (self.ldap_dn, self.ldap_password)
+    creds_encoded = base64.b64encode( credentials.encode('ascii') ) \
+                          .decode('ascii')
+    basic_auth = 'Basic %s' % creds_encoded
+
+    params = urllib.parse.urlencode({ 'domain':   self.domain,
+                                      'hostname': self.hostname,
+                                      'id':       self.id })
+
+    url = 'wss://%s/v1/server_connection?%s' % (self.exam_server_name, params)
+    ws.connect(url,
+               connection='Connection: Upgrade',
+               header={'Authorization': basic_auth})
+
+    return ws
 
 
   def get(self, path, params={}):
@@ -153,6 +209,7 @@ class PuavoErsApplet:
     self.menu.show_all()
 
     exam_server = PuavoExamServer()
+    exam_server.start()
 
     self.exam_sync = PuavoErsExamSync(exam_server, self.exam_sync_active)
     self.exam_sync.start()
@@ -607,8 +664,12 @@ class PuavoErsExamSync (threading.Thread):
 
      while True:
        try:
+         # XXX there should perhaps be some condition variable and this could
+         # XXX be activated by the puavo_exam_server instead of constantly
+         # XXX sleeping
          if self.exam_sync_enabled:
            self.sync_exams()
+           # XXX acquire lock and do sync
          elif is_enabled != self.exam_sync_enabled:
            syslog.syslog(syslog.LOG_INFO, 'exam sync has been disabled')
            is_enabled = self.exam_sync_enabled

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import copy
 import datetime
 import errno
 import fcntl
@@ -113,10 +114,13 @@ class PuavoErsApplet:
     self.exam_sorter = PuavoErsExamSorter(self.exam_sync_active)
     self.exam_sorter.start()
 
+    self.exam_control = PuavoErsExamControl()
+    self.exam_control.start()
+
     self.exams_server_helper = PuavoErsServerHelper()
     self.exams_server_helper.start()
 
-    self.exams_scheduler = PuavoErsExamScheduler()
+    self.exams_scheduler = PuavoErsExamScheduler(self.exam_control)
     self.exams_scheduler.start()
 
     # Copy "naksu" to NAKSU_BIN_PATH only if it does not exist yet.
@@ -666,6 +670,75 @@ class PuavoErsExamSync (threading.Thread):
     syslog.syslog(syslog.LOG_INFO, 'exam %s synced okay' % exam_file_name)
 
 
+class PuavoErsExamControl (threading.Thread):
+  STATUS_PATH = os.path.join(COMM_DIR, '.status.json')
+
+  def __init__(self):
+    threading.Thread.__init__(self)
+
+    self.send_status_update = threading.Condition()
+    self.status = None
+    self.status_updated = False
+
+
+  def run(self):
+    while True:
+      try:
+        self.send_status_update.acquire()
+
+        while not self.status_updated:
+          self.send_status_update.wait()
+
+        status_copy = copy.deepcopy(self.status)
+        self.status_updated = False
+        self.send_status_update.release()
+
+        self.send_status(status_copy)
+      except Exception as e:
+        syslog.syslog(syslog.LOG_ERR,
+                      'error when sending status update: %s' % e)
+
+
+  def send_status(self, status):
+    syslog.syslog(syslog.LOG_INFO, 'sending status update to server')
+
+#     response = requests.get(index_uri,
+#                             auth=HTTPBasicAuth(self.ldap_dn,
+#                                                self.ldap_password),
+#                             params={
+#                               'domain':   self.domain,
+#                               'hostname': self.hostname,
+#                               'id':       self.id,
+#                             },
+#                             timeout=20)
+
+
+  def update_status(self, new_status):
+    self.send_status_update.acquire()
+
+    if self.status != new_status:
+      self.status = new_status
+      syslog.syslog(syslog.LOG_INFO,
+                    'received status update from exam scheduler')
+      self.status_updated = True
+      self.send_status_update.notify()
+
+    self.send_status_update.release()
+
+
+  def save_status_to_disk(self):
+    # This method has no other purpose except to help with
+    # monitoring/debugging.  Perhaps this should be removed?
+    try:
+      tmpfile = '%s.tmp' % self.STATUS_PATH
+      with open(tmpfile, 'w') as f:
+        json.dump(self.status, f)
+      os.rename(tmpfile, self.STATUS_PATH)
+    except Exception as e:
+      syslog.syslog(syslog.LOG_ERR,
+                    'error when saving status to disk: %s' % e)
+
+
 class ExamSet:
   def __init__(self, exams):
     self.exams = exams
@@ -986,10 +1059,11 @@ class PuavoErsExamScheduler (threading.Thread):
   STATS_PATH           = os.path.join(COMM_DIR, 'stats')
 
 
-  def __init__(self):
+  def __init__(self, exam_control):
     threading.Thread.__init__(self)
 
     self.answers_stored_time    = None
+    self.exam_control           = exam_control
     self.exam_scheduler_enabled = False
     self.finished_and_students  = None
     self.finish_time            = self.end_of_today()
@@ -1063,9 +1137,6 @@ class PuavoErsExamScheduler (threading.Thread):
 
     while True:
       try:
-        if not self.exam_scheduler_enabled:
-          raise ExamSchedulerNotActive
-
         if not comm_ok:
           output = self.ping()
           if output['error'] == False:
@@ -1095,7 +1166,7 @@ class PuavoErsExamScheduler (threading.Thread):
         syslog.syslog(syslog.LOG_ERR,
                       'error when scheduling exams: %s' % e)
 
-      time.sleep(20)
+      time.sleep(3)
 
 
   def maybe_store_answers(self, currently_loaded_exams, status):
@@ -1214,6 +1285,11 @@ class PuavoErsExamScheduler (threading.Thread):
     status_response = self.get_status()
     status = status_response['status']
     has_started = (status['hasStarted'] == True)
+
+    self.exam_control.update_status(status)
+
+    if not self.exam_scheduler_enabled:
+      raise ExamSchedulerNotActive
 
     exams_response = self.get_exams()
     currently_loaded_exams = exams_response['exams']

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -18,7 +18,6 @@ import requests
 import shutil
 import signal
 import subprocess
-import sys
 import syslog
 import threading
 import time
@@ -134,8 +133,6 @@ class PuavoExamServer (threading.Thread):
 
 
   def ping(self):
-    # XXX the websocket protocol might support ping/pong with no body
-    # XXX but we have handmade tiny messages
     self.send({ 'type': 'ping' })
 
 
@@ -165,7 +162,6 @@ class PuavoExamServer (threading.Thread):
       syslog.syslog(syslog.LOG_INFO,
                     'received change access code message from exams controller')
       self.exam_scheduler.request_keycode_change()
-      # XXX should return some ack message?
       return
 
     if msg['type'] == 'refresh_exams':
@@ -295,7 +291,6 @@ class PuavoErsApplet:
 
     self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 
-    # XXX do we need this?
     Notify.init('puavo-ers-applet')
 
     os.makedirs(self.PUAVO_ERS_DIR, exist_ok=True)
@@ -459,7 +454,6 @@ class PuavoErsApplet:
       error = e
 
     if error:
-      # XXX should user be notified?
       syslog.syslog(syslog.LOG_ERR,
                     'error when updating decrypt codes: %s' % error)
 
@@ -635,7 +629,8 @@ class PuavoErsApplet:
     self.exam_scheduler.exam_scheduler_enabled = False
     if is_enabled != self.exam_scheduler.exam_scheduler_enabled:
       syslog.syslog(syslog.LOG_INFO, 'exam scheduler is now disabled')
-      Notify.Notification.new(_tr('Exam session automation is NOT active')).show()
+      Notify.Notification.new(_tr('Exam session automation is NOT active')) \
+                         .show()
     self.update_decrypt_codes(True)
 
 
@@ -848,7 +843,6 @@ class PuavoErsExamSync (threading.Thread):
         f.write(exams_json)
       os.rename(tmpfile, EXAMS_JSON_FILE)
     except Exception as e:
-      # XXX should user be notified?
       syslog.syslog(syslog.LOG_CRIT,
         'error in writing exams (json) to %s: %s' % (EXAMS_JSON_FILE, e))
 
@@ -930,8 +924,6 @@ class PuavoErsExamControl (threading.Thread):
     syslog.syslog(syslog.LOG_INFO, 'sending status update to server')
 
     self.status = status
-
-    # XXX is there anything we should do with the response?
 
 
   def update_status(self, new_status):

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -107,9 +107,13 @@ class PuavoExamServer (threading.Thread):
   def run(self):
      while True:
        try:
-         self.exam_sync.trigger_sync_exams()
-
-         self.ws = self.open_connection()
+         try:
+           self.ws = self.open_connection()
+         finally:
+           # Sync exams should be done always after opening a new connection,
+           # even if that fails (because we need a plan B if websocket does
+           # not work).
+           self.exam_sync.trigger_sync_exams()
 
          while True:
            try:
@@ -210,6 +214,36 @@ class PuavoExamServer (threading.Thread):
       return
 
     return response
+
+
+  def post(self, path, data):
+    uri = 'https://%s%s' % (self.exam_server_name, path)
+
+    req_params = {
+                   'domain':   self.domain,
+                   'hostname': self.hostname,
+                   'id':       self.id,
+                 }
+    json_data = json.dumps(data)
+
+    try:
+      response = requests.post(uri,
+                              auth=HTTPBasicAuth(self.ldap_dn,
+                                                 self.ldap_password),
+                              params=req_params,
+                              data=json_data,
+                              timeout=20)
+      if response.status_code != requests.codes.ok:
+        syslog.syslog(syslog.LOG_ERR,
+          'error on POST request to %s: code=%s' % (uri, response.status_code))
+    except Exception as e:
+      syslog.syslog(syslog.LOG_ERR,
+                    'error on POST request to %s: %s' % (uri, e))
+      return
+
+    return response
+
+
 
 
 class PuavoErsApplet:
@@ -696,7 +730,7 @@ class PuavoErsExamSync (threading.Thread):
     self.exam_server = exam_server
     self.exam_sorter = exam_sorter
     self.exam_sync_enabled = is_active
-    self.do_exam_sync = True
+    self.do_exam_sync = False
     self.sync_exams_lock = threading.Condition()
 
 
@@ -735,7 +769,7 @@ class PuavoErsExamSync (threading.Thread):
 
     response = self.exam_server.get('/v1/schedules/query_exam_server_schedule')
     if not response or response.status_code != requests.codes.ok:
-      return
+      raise Exception('could not get exam schedules from server')
 
     exams_json = response.content.decode('utf-8')
     self.update_exams_json_on_disk(exams_json)
@@ -824,22 +858,30 @@ class PuavoErsExamControl (threading.Thread):
 
     self.send_status_update_lock = threading.Condition()
     self.status = None
-    self.status_updated = False
+    self.local_status_updated = False
 
 
   def run(self):
+    status_send_error = False
+
     while True:
       try:
         self.send_status_update_lock.acquire()
 
-        while not self.status_updated:
-          self.send_status_update_lock.wait()
+        if not status_send_error:
+          while not self.local_status_updated:
+            self.send_status_update_lock.wait()
 
         status_copy = copy.deepcopy(self.status)
-        self.status_updated = False
+        self.local_status_updated = False
         self.send_status_update_lock.release()
 
-        self.send_status(status_copy)
+        try:
+          self.send_status(status_copy)
+          status_send_error = False
+        except Exception as e:
+          status_send_error = True
+          raise e
       except Exception as e:
         syslog.syslog(syslog.LOG_ERR,
                       'error when sending status update: %s' % e)
@@ -850,17 +892,18 @@ class PuavoErsExamControl (threading.Thread):
   def send_status(self, status):
     syslog.syslog(syslog.LOG_INFO, 'sending status update to server')
 
-    status_path = '/v1/exam_session_status'
+    msg = {
+      'version':    0,
+      'ers_status': status,
+    }
 
-#     response = requests.get(index_uri,
-#                             auth=HTTPBasicAuth(self.ldap_dn,
-#                                                self.ldap_password),
-#                             params={
-#                               'domain':   self.domain,
-#                               'hostname': self.hostname,
-#                               'id':       self.id,
-#                             },
-#                             timeout=20)
+    response = self.exam_server.post('/v1/servers/status_update', msg)
+    if not response or response.status_code != requests.codes.ok:
+      raise Exception('could not send status update to server')
+
+    self.status = status
+
+    # XXX is there anything we should do with the response?
 
 
   def update_status(self, new_status):
@@ -870,7 +913,7 @@ class PuavoErsExamControl (threading.Thread):
       self.status = new_status
       syslog.syslog(syslog.LOG_INFO,
                     'received status update from exam scheduler')
-      self.status_updated = True
+      self.local_status_updated = True
       self.send_status_update_lock.notify()
 
     self.send_status_update_lock.release()

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -916,16 +916,11 @@ class PuavoErsExamControl (threading.Thread):
 
 
   def send_status(self, status):
-    syslog.syslog(syslog.LOG_INFO, 'sending status update to server')
-
-    msg = {
-      'version':    0,
-      'ers_status': status,
-    }
-
-    response = self.exam_server.post('/v1/servers/status_update', msg)
+    response = self.exam_server.post('/v1/servers/status_update', status)
     if not response or response.status_code != requests.codes.ok:
       raise Exception('could not send status update to server')
+
+    syslog.syslog(syslog.LOG_INFO, 'sending status update to server')
 
     self.status = status
 

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -113,20 +113,49 @@ class PuavoExamServer (threading.Thread):
          # XXX have a timeout of one hour or something?
 
          while self.ws:
-           self.handle_message( self.ws.recv() )
+           try:
+             self.handle_message( self.ws.recv() )
+           except websocket.WebSocketTimeoutException as e:
+             self.ping()
        except Exception as e:
-         syslog.syslog(syslog.LOG_ERR, 'error with server connection: %s' % e)
+         syslog.syslog(syslog.LOG_ERR,
+                       'error with websocket connection: %s' % e)
        finally:
          if self.ws:
+           syslog.syslog(syslog.LOG_INFO, 'closing websocket connection')
            self.ws.close()
            self.ws = None
 
        time.sleep(10)
 
 
-  def handle_message(self, msg):
-    # XXX
-    syslog.syslog(syslog.LOG_INFO, 'we got a message: %s' % msg)
+  def ping(self):
+    self.send({ 'type': 'ping' })
+
+
+  def send(self, msg):
+     self.ws.send( json.dumps(msg) )
+
+
+  def handle_message(self, msgjson):
+    msg = json.loads(msgjson)
+    if type(msg) != dict:
+      raise Exception('message is not a dict')
+    if not 'type' in msg:
+      raise Exception('message does not have a type')
+    if msg['type'] != str:
+      raise Exception('message type is not a string')
+
+    if msg['type'] == 'pong':
+      return
+
+    if msg['type'] == 'check_exam_session_access_code':
+      # XXX should do something useful
+      return
+
+    if msg['type'] == 'refresh_exams':
+      # XXX should do something useful
+      return
 
 
   def open_connection(self):
@@ -144,7 +173,8 @@ class PuavoExamServer (threading.Thread):
     url = 'wss://%s/v1/server_connection?%s' % (self.exam_server_name, params)
     ws.connect(url,
                connection='Connection: Upgrade',
-               header={'Authorization': basic_auth})
+               header={'Authorization': basic_auth},
+               timeout=45)
 
     return ws
 
@@ -677,6 +707,7 @@ class PuavoErsExamSync (threading.Thread):
        except Exception as e:
          syslog.syslog(syslog.LOG_ERR, 'error when syncing exams: %s' % e)
 
+       # XXX this should be longer I think, but not bigger than 3600
        time.sleep(60)
 
 

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -100,19 +100,18 @@ class PuavoExamServer (threading.Thread):
     self.ws = None
 
 
+  def add_other_threads(self, exam_sync):
+    self.exam_sync = exam_sync
+
+
   def run(self):
      while True:
        try:
+         self.exam_sync.trigger_sync_exams()
+
          self.ws = self.open_connection()
 
-         # XXX we should fetch exam index in case we are here
-         # XXX (those might have been updated when we have not had a
-         # XXX connection and we would not have gotten a notification about it)
-         # XXX time is also another factor... received data changes as time
-         # XXX goes past.... so the exam fetch condition variable should
-         # XXX have a timeout of one hour or something?
-
-         while self.ws:
+         while True:
            try:
              self.handle_message( self.ws.recv() )
            except websocket.WebSocketTimeoutException as e:
@@ -126,10 +125,12 @@ class PuavoExamServer (threading.Thread):
            self.ws.close()
            self.ws = None
 
-       time.sleep(10)
+       time.sleep(60)
 
 
   def ping(self):
+    # XXX the websocket protocol might support ping/pong with no body
+    # XXX but we have handmade tiny messages
     self.send({ 'type': 'ping' })
 
 
@@ -143,18 +144,23 @@ class PuavoExamServer (threading.Thread):
       raise Exception('message is not a dict')
     if not 'type' in msg:
       raise Exception('message does not have a type')
-    if msg['type'] != str:
+    if type(msg['type']) != str:
       raise Exception('message type is not a string')
 
     if msg['type'] == 'pong':
       return
 
-    if msg['type'] == 'check_exam_session_access_code':
-      # XXX should do something useful
+    if msg['type'] == 'change_exam_session_access_code':
+      # XXX don't just log, do something!
+      syslog.syslog(syslog.LOG_INFO,
+                    'received change exam session access code message from' \
+                      + ' exams controller')
       return
 
     if msg['type'] == 'refresh_exams':
-      # XXX should do something useful
+      syslog.syslog(syslog.LOG_INFO,
+                    'received refresh exams messages from exams controller')
+      self.exam_sync.trigger_sync_exams()
       return
 
 
@@ -238,23 +244,22 @@ class PuavoErsApplet:
 
     self.menu.show_all()
 
-    exam_server = PuavoExamServer()
-    exam_server.start()
-
-    self.exam_sync = PuavoErsExamSync(exam_server, self.exam_sync_active)
-    self.exam_sync.start()
-
+    self.exam_server = PuavoExamServer()
+    self.exam_sync = PuavoErsExamSync(self.exam_server, self.exam_sync_active)
+    self.exam_control = PuavoErsExamControl(self.exam_server)
     self.exam_sorter = PuavoErsExamSorter(self.exam_sync_active)
+    self.exam_server_helper = PuavoErsServerHelper()
+    self.exam_scheduler = PuavoErsExamScheduler(self.exam_control)
+
+    self.exam_server.add_other_threads(self.exam_sync)
+
+    self.exam_server.start()
+    self.exam_sync.start()
     self.exam_sorter.start()
-
-    self.exam_control = PuavoErsExamControl(exam_server)
     self.exam_control.start()
+    self.exam_server_helper.start()
+    self.exam_scheduler.start()
 
-    self.exams_server_helper = PuavoErsServerHelper()
-    self.exams_server_helper.start()
-
-    self.exams_scheduler = PuavoErsExamScheduler(self.exam_control)
-    self.exams_scheduler.start()
 
     # Copy "naksu" to NAKSU_BIN_PATH only if it does not exist yet.
     # This is because "naksu" is self-updating and self.NAKSU_BIN_PATH
@@ -494,7 +499,7 @@ class PuavoErsApplet:
     self.menuitems.append(separator)
     self.menu.append(separator)
 
-    if self.exams_scheduler.exam_scheduler_enabled:
+    if self.exam_scheduler.exam_scheduler_enabled:
       auto_info_button = Gtk.MenuItem(
         label=_tr('Exam session automation is active'))
       auto_info_button.set_sensitive(False)
@@ -540,6 +545,8 @@ class PuavoErsApplet:
     self.exam_sync_active = True
     self.save_configuration()
 
+    self.exam_sync.trigger_sync_exams()
+
     self.exam_sorter.exam_sorter_enabled = True
     self.exam_sync.exam_sync_enabled     = True
     self.update_decrypt_codes(True)
@@ -556,9 +563,9 @@ class PuavoErsApplet:
       self.automation_active = False
       self.save_configuration()
 
-    is_enabled = self.exams_scheduler.exam_scheduler_enabled
-    self.exams_scheduler.exam_scheduler_enabled = False
-    if is_enabled != self.exams_scheduler.exam_scheduler_enabled:
+    is_enabled = self.exam_scheduler.exam_scheduler_enabled
+    self.exam_scheduler.exam_scheduler_enabled = False
+    if is_enabled != self.exam_scheduler.exam_scheduler_enabled:
       syslog.syslog(syslog.LOG_INFO, 'exam scheduler is now disabled')
       Notify.Notification.new(_tr('Exam session automation is NOT active')).show()
     self.update_decrypt_codes(True)
@@ -613,9 +620,9 @@ class PuavoErsApplet:
       Notify.Notification.new(summary, body).show()
       return
 
-    is_enabled = self.exams_scheduler.exam_scheduler_enabled
-    self.exams_scheduler.exam_scheduler_enabled = True
-    if is_enabled != self.exams_scheduler.exam_scheduler_enabled:
+    is_enabled = self.exam_scheduler.exam_scheduler_enabled
+    self.exam_scheduler.exam_scheduler_enabled = True
+    if is_enabled != self.exam_scheduler.exam_scheduler_enabled:
       Notify.Notification.new(_tr('Exam session automation is active')).show()
       syslog.syslog(syslog.LOG_INFO, 'exam scheduler is now enabled')
 
@@ -687,28 +694,39 @@ class PuavoErsExamSync (threading.Thread):
 
     self.exam_server = exam_server
     self.exam_sync_enabled = is_active
+    self.do_exam_sync = True
+    self.sync_exams_lock = threading.Condition()
 
 
   def run(self):
      is_enabled = None
+     self.sync_exams_lock.acquire()
 
      while True:
        try:
-         # XXX there should perhaps be some condition variable and this could
-         # XXX be activated by the puavo_exam_server instead of constantly
-         # XXX sleeping
+         # we do not check with while, because periodically sync_exams()
+         # should be run, as clock ticks forward
+         if not self.do_exam_sync:
+           self.sync_exams_lock.wait(timeout=3600)
+
          if self.exam_sync_enabled:
            self.sync_exams()
-           # XXX acquire lock and do sync
          elif is_enabled != self.exam_sync_enabled:
            syslog.syslog(syslog.LOG_INFO, 'exam sync has been disabled')
            is_enabled = self.exam_sync_enabled
+         self.do_exam_sync = False
 
        except Exception as e:
          syslog.syslog(syslog.LOG_ERR, 'error when syncing exams: %s' % e)
 
-       # XXX this should be longer I think, but not bigger than 3600
-       time.sleep(60)
+       time.sleep(10)
+
+
+  def trigger_sync_exams(self):
+    self.sync_exams_lock.acquire()
+    self.do_exam_sync = True
+    self.sync_exams_lock.notify()
+    self.sync_exams_lock.release()
 
 
   def sync_exams(self):
@@ -795,7 +813,7 @@ class PuavoErsExamControl (threading.Thread):
 
     self.exam_server = exam_server
 
-    self.send_status_update = threading.Condition()
+    self.send_status_update_lock = threading.Condition()
     self.status = None
     self.status_updated = False
 
@@ -803,19 +821,21 @@ class PuavoErsExamControl (threading.Thread):
   def run(self):
     while True:
       try:
-        self.send_status_update.acquire()
+        self.send_status_update_lock.acquire()
 
         while not self.status_updated:
-          self.send_status_update.wait()
+          self.send_status_update_lock.wait()
 
         status_copy = copy.deepcopy(self.status)
         self.status_updated = False
-        self.send_status_update.release()
+        self.send_status_update_lock.release()
 
         self.send_status(status_copy)
       except Exception as e:
         syslog.syslog(syslog.LOG_ERR,
                       'error when sending status update: %s' % e)
+
+      time.sleep(10)
 
 
   def send_status(self, status):
@@ -835,16 +855,16 @@ class PuavoErsExamControl (threading.Thread):
 
 
   def update_status(self, new_status):
-    self.send_status_update.acquire()
+    self.send_status_update_lock.acquire()
 
     if self.status != new_status:
       self.status = new_status
       syslog.syslog(syslog.LOG_INFO,
                     'received status update from exam scheduler')
       self.status_updated = True
-      self.send_status_update.notify()
+      self.send_status_update_lock.notify()
 
-    self.send_status_update.release()
+    self.send_status_update_lock.release()
 
 
   def save_status_to_disk(self):

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -76,6 +76,49 @@ class ExamSchedulerNotActive(Exception):
   pass
 
 
+class PuavoExamServer:
+  def __init__(self):
+    self.exam_server_name = puavoconf_get('puavo.abitti.exam_server')
+
+    with open('/etc/puavo/domain') as f:
+      self.domain = f.read().rstrip()
+    with open('/etc/puavo/hostname') as f:
+      self.hostname = f.read().rstrip()
+    with open('/etc/puavo/id') as f:
+      self.id = f.read().rstrip()
+    with open('/etc/puavo/ldap/dn') as f:
+      self.ldap_dn = f.read().rstrip()
+    with open('/etc/puavo/ldap/password') as f:
+      self.ldap_password = f.read().rstrip()
+
+
+  def get(self, path, params={}):
+    uri = 'https://%s%s' % (self.exam_server_name, path)
+
+    req_params = params
+    req_params.update({
+                        'domain':   self.domain,
+                        'hostname': self.hostname,
+                        'id':       self.id,
+                      })
+
+    try:
+      response = requests.get(uri,
+                              auth=HTTPBasicAuth(self.ldap_dn,
+                                                 self.ldap_password),
+                              params=req_params,
+                              timeout=20)
+      if response.status_code != requests.codes.ok:
+        syslog.syslog(syslog.LOG_ERR,
+          'error on GET request to %s: code=%s' % (uri, response.status_code))
+    except Exception as e:
+      syslog.syslog(syslog.LOG_ERR,
+                    'error on GET request to %s: %s' % (uri, e))
+      return
+
+    return response
+
+
 class PuavoErsApplet:
   NAKSU_ORIGIN_PATH = '/opt/abitti-naksu/naksu'
   PUAVO_ERS_DIR = os.path.join(os.environ['HOME'], '.puavo', 'puavo-ers')
@@ -108,13 +151,15 @@ class PuavoErsApplet:
 
     self.menu.show_all()
 
-    self.exam_sync = PuavoErsExamSync(self.exam_sync_active)
+    exam_server = PuavoExamServer()
+
+    self.exam_sync = PuavoErsExamSync(exam_server, self.exam_sync_active)
     self.exam_sync.start()
 
     self.exam_sorter = PuavoErsExamSorter(self.exam_sync_active)
     self.exam_sorter.start()
 
-    self.exam_control = PuavoErsExamControl()
+    self.exam_control = PuavoErsExamControl(exam_server)
     self.exam_control.start()
 
     self.exams_server_helper = PuavoErsServerHelper()
@@ -538,21 +583,11 @@ class DecryptCodesWindow:
 
 
 class PuavoErsExamSync (threading.Thread):
-  def __init__(self, is_active):
+  def __init__(self, exam_server, is_active):
     threading.Thread.__init__(self)
 
+    self.exam_server = exam_server
     self.exam_sync_enabled = is_active
-
-    with open('/etc/puavo/domain') as f:
-      self.domain = f.read().rstrip()
-    with open('/etc/puavo/hostname') as f:
-      self.hostname = f.read().rstrip()
-    with open('/etc/puavo/id') as f:
-      self.id = f.read().rstrip()
-    with open('/etc/puavo/ldap/dn') as f:
-      self.ldap_dn = f.read().rstrip()
-    with open('/etc/puavo/ldap/password') as f:
-      self.ldap_password = f.read().rstrip()
 
 
   def run(self):
@@ -573,25 +608,10 @@ class PuavoErsExamSync (threading.Thread):
 
 
   def sync_exams(self):
-    self.exam_server_address = puavoconf_get('puavo.abitti.exam_server')
-    index_uri = 'https://%s/v1/schedules/query_exam_server_schedule' \
-                   % self.exam_server_address
+    syslog.syslog(syslog.LOG_INFO, 'requesting for new exams')
 
-    syslog.syslog(syslog.LOG_INFO, 'checking for new exams from %s' % index_uri)
-
-    response = requests.get(index_uri,
-                            auth=HTTPBasicAuth(self.ldap_dn,
-                                               self.ldap_password),
-                            params={
-                              'domain':   self.domain,
-                              'hostname': self.hostname,
-                              'id':       self.id,
-                            },
-                            timeout=20)
-    if not response:
-      syslog.syslog(syslog.LOG_ERR,
-        'error when getting exam index from %s: %s' \
-          % (index_uri, response.status_code))
+    response = self.exam_server.get('/v1/schedules/query_exam_server_schedule')
+    if not response or response.status_code != requests.codes.ok:
       return
 
     exams_json = response.content.decode('utf-8')
@@ -646,21 +666,10 @@ class PuavoErsExamSync (threading.Thread):
     if not isinstance(exam_hash, str):
       raise Exception('could not determine exam hash for %s' % exam_file_name)
 
-    exam_uri = 'https://%s/v1/exams/raw_file' % self.exam_server_address
-
-    response = requests.get(exam_uri,
-                            auth=HTTPBasicAuth(self.ldap_dn,
-                                               self.ldap_password),
-                            params={
-                              'domain':   self.domain,
-                              'hash':     exam_hash,
-                              'hostname': self.hostname,
-                              'id':       self.id,
-                            },
-                            timeout=20)
-    if not response:
-      raise Exception('error when getting an exam from %s: %s' \
-              % (exam_uri, response.status_code))
+    exam_params = { 'hash': exam_hash }
+    response = self.exam_server.get('/v1/exams/raw_file', exam_params)
+    if not response or response.status_code != requests.codes.ok:
+      raise Exception('error when getting an exam %s' % exam_file_name)
 
     tmpfile = '%s.tmp' % exam_file_path
     with open(tmpfile, 'wb') as f:
@@ -673,8 +682,10 @@ class PuavoErsExamSync (threading.Thread):
 class PuavoErsExamControl (threading.Thread):
   STATUS_PATH = os.path.join(COMM_DIR, '.status.json')
 
-  def __init__(self):
+  def __init__(self, exam_server):
     threading.Thread.__init__(self)
+
+    self.exam_server = exam_server
 
     self.send_status_update = threading.Condition()
     self.status = None
@@ -701,6 +712,8 @@ class PuavoErsExamControl (threading.Thread):
 
   def send_status(self, status):
     syslog.syslog(syslog.LOG_INFO, 'sending status update to server')
+
+    status_path = '/v1/exam_session_status'
 
 #     response = requests.get(index_uri,
 #                             auth=HTTPBasicAuth(self.ldap_dn,

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -9,6 +9,7 @@ import filecmp
 import gettext
 import gi
 import glob
+import hashlib
 import json
 import os
 import re
@@ -671,9 +672,13 @@ class PuavoErsExamSync (threading.Thread):
     if not response or response.status_code != requests.codes.ok:
       raise Exception('error when getting an exam %s' % exam_file_name)
 
+    exam_contents = response.content
+    if exam_hash != hashlib.sha256(exam_contents).hexdigest():
+      raise Exception('exam checksum did not match for %s' % exam_file_name)
+
     tmpfile = '%s.tmp' % exam_file_path
     with open(tmpfile, 'wb') as f:
-      f.write(response.content)
+      f.write(exam_contents)
     os.rename(tmpfile, exam_file_path)
 
     syslog.syslog(syslog.LOG_INFO, 'exam %s synced okay' % exam_file_name)

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -280,9 +280,17 @@ class PuavoErsApplet:
     error = None
     try:
       with open(EXAMS_JSON_FILE) as file:
-        new_exams = json.load(file)
+        error_no_exams = False
+        try:
+          new_exams = json.load(file)
+        except Exception as e:
+          error_no_exams = True
+          new_exams = []
+          syslog.syslog(syslog.LOG_ERR,
+                        'could not parse exams json: %s' % e)
+
         if (force_update or self.old_exams != new_exams):
-          self.update_decrypt_codes_in_ui(new_exams)
+          self.update_decrypt_codes_in_ui(new_exams, error_no_exams)
         self.old_exams = new_exams
     except OSError as e:
       if e.errno != errno.ENOENT:
@@ -298,7 +306,7 @@ class PuavoErsApplet:
     return True
 
 
-  def update_decrypt_codes_in_ui(self, new_exams):
+  def update_decrypt_codes_in_ui(self, new_exams, error_no_exams):
     # We can show decrypt codes for future exams as well, in case user
     # wants to try those out manually.  Showing them for old exams is probably
     # just a distraction.
@@ -364,7 +372,10 @@ class PuavoErsApplet:
         self.menuitems.append(button)
 
     else:
-      instructions = Gtk.MenuItem(label=_tr('No current exams'))
+      no_exams_message = _tr('No current exams')
+      if error_no_exams:
+        no_exams_message = _tr('No exams due to error')
+      instructions = Gtk.MenuItem(label=no_exams_message)
       instructions.set_sensitive(False)
       instructions.show()
       self.menuitems.append(instructions)

--- a/parts/ers/puavo-ers-applet
+++ b/parts/ers/puavo-ers-applet
@@ -180,17 +180,43 @@ class PuavoExamServer (threading.Thread):
                                       'hostname': self.hostname,
                                       'id':       self.id })
 
-    url = 'wss://%s/v1/server_connection?%s' % (self.exam_server_name, params)
+    url = self.server_uri('/v1/server_connection?%s' % params, True)
     ws.connect(url,
                connection='Connection: Upgrade',
                header={'Authorization': basic_auth},
                timeout=45)
 
+    syslog.syslog(syslog.LOG_INFO,
+                  'websocket connection opened to exam control server')
+
     return ws
 
 
+  def server_uri(self, path, websocket=False):
+    if self.exam_server_name.startswith('http://'):
+      server_name = self.exam_server_name.replace('http://', '')
+      use_http = True
+    elif self.exam_server_name.startswith('https://'):
+      server_name = self.exam_server_name.replace('https://', '')
+      use_http = False
+    else:
+      server_name = self.exam_server_name
+      use_http = False
+
+    if websocket:
+      if use_http:
+        return 'ws://%s%s' % (server_name, path)
+      else:
+        return 'wss://%s%s' % (server_name, path)
+    else:
+      if use_http:
+        return 'http://%s%s' % (server_name, path)
+      else:
+        return 'https://%s%s' % (server_name, path)
+
+
   def get(self, path, params={}):
-    uri = 'https://%s%s' % (self.exam_server_name, path)
+    uri = self.server_uri(path)
 
     req_params = params
     req_params.update({
@@ -217,7 +243,7 @@ class PuavoExamServer (threading.Thread):
 
 
   def post(self, path, data):
-    uri = 'https://%s%s' % (self.exam_server_name, path)
+    uri = self.server_uri(path)
 
     req_params = {
                    'domain':   self.domain,

--- a/parts/ltsp/client/puavo-test-hardware
+++ b/parts/ltsp/client/puavo-test-hardware
@@ -313,7 +313,7 @@ test_speakers() {
   # XXX This uses wav files that might no longer exist after
   # XXX Scratch or Solfege is updated.
   aplay --device="${alsadev}" \
-	/usr/share/scratch/Media/Sounds/Vocals/Singer1.wav \
+        /usr/share/scratch/Media/Sounds/Vocals/Singer1.wav \
         /usr/share/scratch/Media/Sounds/Electronic/ComputerBeeps1.wav \
         /usr/share/scratch/Media/Sounds/Human/Laugh-female.wav \
         /usr/share/solfege/exercises/standard/lesson-files/share/fanfare.wav \

--- a/parts/ltsp/client/puavo-test-hardware
+++ b/parts/ltsp/client/puavo-test-hardware
@@ -287,14 +287,8 @@ test_mouse() {
 
 test_microphone() {
   local alsadev
+  alsadev='plughw:CARD=PCH'
   clear
-  product_name=`cat /sys/class/dmi/id/product_name`
-  case "$product_name" in
-    "HP EliteBook 820 G1" | "HP EliteBook 840 G1" | "HP EliteBook 820 G2" | "HP EliteBook 840 G2" )
-      alsadev='hw:1,0' ;;
-    *)
-      alsadev='hw:0,0' ;;
-  esac
   echo "Using ALSA device ${alsadev} for recording..."
   echo
 
@@ -308,28 +302,23 @@ test_microphone() {
 
 test_speakers() {
   local speaker_test_status
-
-  clear
+  local alsadev
   speaker_test_status=0
-  product_name=`cat /sys/class/dmi/id/product_name`
-  case "$product_name" in
-    "HP EliteBook 820 G1" | "HP EliteBook 840 G1" | "HP EliteBook 820 G2" | "HP EliteBook 840 G2" )
-      alsadev='hw:1,0'
-      speaker-test --device="${alsadev}" -t wav  -c 2 -l 3 || speaker_test_status=1
-      speaker-test --device="${alsadev}" -t pink -c 2 -l 1 || speaker_test_status=1 ;;
-    *)
-      alsadev='default'
-      speaker-test --device="${alsadev}" -t wav  -c 2 -l 3 || speaker_test_status=1
-      speaker-test --device="${alsadev}" -t pink -c 2 -l 1 || speaker_test_status=1
 
-      # XXX This uses wav files that might no longer exist after
-      # XXX Scratch or Solfege is updated.
-      aplay /usr/share/scratch/Media/Sounds/Vocals/Singer1.wav \
-            /usr/share/scratch/Media/Sounds/Electronic/ComputerBeeps1.wav \
-            /usr/share/scratch/Media/Sounds/Human/Laugh-female.wav \
-            /usr/share/solfege/exercises/standard/lesson-files/share/fanfare.wav \
-        || speaker_test_status=1;;
-  esac
+  alsadev='plughw:CARD=PCH'
+  clear
+  speaker-test --device="${alsadev}" -t wav -p 256 -c 2 -l 2 || speaker_test_status=1
+  speaker-test --device="${alsadev}" -t pink -p 256 -c 2 -l 1 || speaker_test_status=1
+
+  # XXX This uses wav files that might no longer exist after
+  # XXX Scratch or Solfege is updated.
+  aplay --device="${alsadev}" \
+	/usr/share/scratch/Media/Sounds/Vocals/Singer1.wav \
+        /usr/share/scratch/Media/Sounds/Electronic/ComputerBeeps1.wav \
+        /usr/share/scratch/Media/Sounds/Human/Laugh-female.wav \
+        /usr/share/solfege/exercises/standard/lesson-files/share/fanfare.wav \
+    || speaker_test_status=1
+
   sleep 2
 }
 


### PR DESCRIPTION
This seems to work on multiple device models and generations.
Had to add a '-p 256' flag to 'speaker-test' to avoid a "Broken pipe" -error.
In addition to enabling the full use of speakertest on EliteBook G1/G2's, the tests are in result more "generalized", at the moment showing no need to workaround some device type specifically.

Tested on EliteBooks (G1 through G5) and some Dells.