### PR TITLE
Add selections 'Import Student laptop BIOS Config' and 'Import USB St…

### DIFF
--- a/parts/ltsp/puavo-install/puavo-bios-config
+++ b/parts/ltsp/puavo-install/puavo-bios-config
@@ -5,14 +5,14 @@ set -eu
 prepare_hp_utils() {
   puavo-conf puavo.pkg.hp-bios-utils latest
   puavo-pkg-update hp-bios-utils
+  export PATH="/opt/hp/hp-flash:${PATH}"
+  hp_utils_dir='/opt/hp/hp-flash'
 }
 
 use_hp_utils() {
   prepare_hp_utils
-
-  export PATH="/opt/hp/hp-flash:${PATH}"
-  hp_utils_dir='/opt/hp/hp-flash'
-  cat <<EOF
+ 
+  cat << EOF
 > Running Bash for you, the current working directory is "${hp_utils_dir}".
 > It has "hp-flash" and "hp-repsetup".
 > PATH is $PATH
@@ -21,8 +21,22 @@ EOF
   (cd "$hp_utils_dir" && bash)
 }
 
+import_config_student_laptop() {
+  prepare_hp_utils
+
+  (cd "$hp_utils_dir" && hp-repsetup -s HpSetup-student-laptop.txt)
+}
+
+import_config_usb_stick_factory() {
+  prepare_hp_utils
+
+  (cd "$hp_utils_dir" && hp-repsetup -s HpSetup-usb-factory.txt)
+}
+
 ask_choice() {
   choices=$(cat <<'EOF')
+Import Student laptop BIOS Config
+Import USB Stick factory BIOS Config
 use HP BIOS utilities
 exit
 EOF
@@ -42,7 +56,16 @@ case "$chosen" in
   exit)
     exit 0
     ;;
+  'Import Student laptop BIOS Config')
+    import_config_student_laptop
+    ;;
+  'Import USB Stick factory BIOS Config')
+    import_config_usb_stick_factory
+    ;;
   'use HP BIOS utilities')
     use_hp_utils
     ;;
 esac
+
+
+


### PR DESCRIPTION
…ick factory BIOS Config'

'Import Student laptop BIOS Config' uses 'hp-repsetup' to setup the device BIOS with the settings defined in the provided config file ('HpSetup-student-laptop.txt').
'Import USB Stick factory BIOS Config' does the same as above but uses other config file with different settings ('HpSetup-usb-factory.txt').

I tested this on one netboot device and the script ran without problems.
Changes to puavo-pkg handling is most likely required for this to work "out of the box" on netboot devices.