### PR TITLE
Add new script 'puavo-disk-erase' and update 'puavo-bios-config' with better BIOS flashing

### DIFF
--- a/parts/ltsp/client/lib/darkdm
+++ b/parts/ltsp/client/lib/darkdm
@@ -363,7 +363,7 @@ EOF
 
 darkdm_print_short_help() {
   darkdm_print_help \
-    | awk '$1 !~ /bios|expert|mount|reboot|preinstall|savedisk/'
+    | awk '$1 !~ /bios|erase|expert|mount|reboot|preinstall|savedisk/'
 }
 
 darkdm_shell()

--- a/parts/ltsp/client/lib/darkdm
+++ b/parts/ltsp/client/lib/darkdm
@@ -338,6 +338,7 @@ Puavo OS Command Shell
 
 Commands:
   bios                   configure BIOS (only on some supported machines)
+  erase                  secure erase a disk (only on SSD's that support it)
   expert-install         install Puavo OS with more detailed questions
   expert-preinstall      install without registering, expert mode
   help                   show more detailed help
@@ -530,6 +531,9 @@ darkdm_menu()
     case "$command" in
       bios)
         puavo-bios-config || return 1
+        ;;
+      erase)
+        puavo-disk-erase || return 1
         ;;
       expert-install)
         darkdm_install expert-install || return 1

--- a/parts/ltsp/puavo-install/Makefile
+++ b/parts/ltsp/puavo-install/Makefile
@@ -34,6 +34,7 @@ install : installdirs
 		puavo-bios-config \
 		puavo-client-daemon \
 		puavo-disk-clone \
+		puavo-disk-erase \
 		puavo-install \
 		puavo-install-and-update-ltspimages \
 		puavo-install-grub \

--- a/parts/ltsp/puavo-install/puavo-bios-config
+++ b/parts/ltsp/puavo-install/puavo-bios-config
@@ -25,12 +25,11 @@ hp_wget_latest_and_flash() {
 
   mainboard_sysid=$(dmidecode -s baseboard-product-name)
   hp_ftp_url="https://ftp.ext.hp.com/pub/pcbios"
-  cd "$hp_utils_dir"
-  wget "$hp_ftp_url/$mainboard_sysid/$mainboard_sysid.xml"
-  hp_latest_bios="$(xmllint --xpath "string(/BIOS/Rel/@Bin)" $mainboard_sysid.xml)"
-  wget "$hp_ftp_url/$mainboard_sysid/$hp_latest_bios"
-  hp-flash "$hp_latest_bios"
-  exit 1
+  (cd "$hp_utils_dir" && \
+    wget "$hp_ftp_url/$mainboard_sysid/$mainboard_sysid.xml" && \
+    hp_latest_bios="$(xmllint --xpath "string(/BIOS/Rel/@Bin)" $mainboard_sysid.xml)" && \
+    wget "$hp_ftp_url/$mainboard_sysid/$hp_latest_bios" && \
+    hp-flash "$hp_latest_bios")
 }
 
 import_config_student_laptop() {

--- a/parts/ltsp/puavo-install/puavo-bios-config
+++ b/parts/ltsp/puavo-install/puavo-bios-config
@@ -20,10 +20,17 @@ EOF
   (cd "$hp_utils_dir" && bash)
 }
 
-flash_bios_update_elitebook_g3() {
+hp_wget_latest_and_flash() {
   prepare_hp_utils
 
-  (cd "$hp_utils_dir" && hp-flash bios-elitebook-g3.bin)
+  mainboard_sysid=$(dmidecode -s baseboard-product-name)
+  hp_ftp_url="https://ftp.ext.hp.com/pub/pcbios"
+  cd "$hp_utils_dir"
+  wget "$hp_ftp_url/$mainboard_sysid/$mainboard_sysid.xml"
+  hp_latest_bios="$(xmllint --xpath "string(/BIOS/Rel/@Bin)" $mainboard_sysid.xml)"
+  wget "$hp_ftp_url/$mainboard_sysid/$hp_latest_bios"
+  hp-flash "$hp_latest_bios"
+  exit 1
 }
 
 import_config_student_laptop() {
@@ -40,7 +47,7 @@ import_config_usb_stick_factory() {
 
 ask_choice() {
   choices=$(cat <<'EOF')
-Flash Elitebook G3 bios
+Flash latest BIOS (HP)
 Import Student laptop BIOS Config
 Import USB Stick factory BIOS Config
 use HP BIOS utilities
@@ -62,8 +69,8 @@ case "$chosen" in
   exit)
     exit 0
     ;;
-  'Flash Elitebook G3 bios')
-    flash_bios_update_elitebook_g3
+  'Flash latest BIOS (HP)')
+    hp_wget_latest_and_flash
     sleep 3
     ;;
   'Import Student laptop BIOS Config')

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -21,7 +21,8 @@ secure_erase() {
   case "${target_disk}" in
     *nvme*)
       echo 'Selected disk is an NVMe disk. Using "nvme-cli" utility for Secure Erase.'
-      nvme format -s1 "${target_disk}"
+      time nvme format -s1 "${target_disk}"
+      echo 'You may check how long the erase took above.'
       exit 1
       ;;
     *)
@@ -71,9 +72,10 @@ secure_erase() {
         exit 1
       fi
 
-      echo 'User and password set, ready for secure erase.'
-      hdparm --user-master user --security-erase Pass "${target_disk}"
-      echo 'Command completed. If you see no errors above, you may now reboot the device.'
+      echo 'User and password set, proceeding to Secure Erase.'
+      time hdparm --user-master user --security-erase Pass "${target_disk}"
+      echo 'Command completed. You may check how long the erase took above.'
+      echo 'If you see no errors, you may re-plug the disk or reboot the device.'
       ;;
   esac
 }

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -18,55 +18,64 @@ secure_erase() {
   fi
 
   echo "Chosen << ${target_disk} >>"
-  if udevadm info --query=all --name="${target_disk}" | grep 'ID_BUS=usb'; then
-    echo 'Selected disk is a USB device, I do not support them. Aborting..' >&2
-    exit 1
-  fi
+  case "${target_disk}" in
+    *nvme*)
+      echo 'Selected disk is an NVMe disk. Using nvme-cli utility...'
+      nvme format -s1 "${target_disk}"
+      exit 1
+      ;;
+    *)
+      if udevadm info --query=all --name="${target_disk}" | grep 'ID_BUS=usb'; then
+        echo 'Selected disk is a USB device, I do not support them. Aborting..' >&2
+        exit 1
+      fi
 
-  if ! hdparm -I "${target_disk}" | grep -P "SECURITY ERASE UNIT" >&2; then
-    echo 'Selected disk does not support Secure Erase!' >&2
-    exit 1
-  fi
+      if ! hdparm -I "${target_disk}" | grep -P "SECURITY ERASE UNIT" >&2; then
+        echo 'Selected disk does not support Secure Erase!' >&2
+        exit 1
+      fi
 
-  echo 'Disk supports Secure Erase.'
-  if ! hdparm -I "${target_disk}" | grep -P "not\tfrozen" >&2; then
-    echo 'Disk is in frozen state, aborting!' >&2
-    echo 'Please close the lid of the device for a few seconds, reopen it and try again.' >&2
-    echo
-    echo 'If we are netbooted, closing the lid will not put the device to sleep.'
-    echo 'We can however put it to sleep and wake it up with the usage of rtcwake.'
-    echo
-    read -p "Shall I run the command for you now? (y/n)[y] " gosleep
-      case $gosleep in
-        [yY]|"")
-          echo 'Going to sleep now.'
-          sleep 1
-          rtcwake -m mem -s 5
-          ;;
-        [nN])
-          echo 'Not going to sleep. You must close and reopen the lid, or run the command by hand. Then retry.'
-          sleep 1
-          exit 1
-          ;;
-        *)
-          echo 'Invalid answer, exiting.' >&2
-          sleep 1
-          exit 1
-          ;;
-      esac
-    exit 1
-  fi
+      echo 'Disk supports Secure Erase.'
+        if ! hdparm -I "${target_disk}" | grep -P "not\tfrozen" >&2; then
+        echo 'Disk is in frozen state, aborting!' >&2
+        echo 'Please close the lid of the device for a few seconds, reopen it and try again.' >&2
+        echo
+        echo 'If we are netbooted, closing the lid will not put the device to sleep.'
+        echo 'We can however put it to sleep and wake it up with the usage of rtcwake.'
+        echo
+        read -p "Shall I run the command for you now? (y/n)[y] " gosleep
+        case $gosleep in
+          [yY]|"")
+            echo 'Going to sleep now.'
+            sleep 1
+            rtcwake -m mem -s 5
+            ;;
+          [nN])
+            echo 'Not going to sleep. You must close and reopen the lid, or run the command by hand. Then retry.'
+            sleep 1
+            exit 1
+            ;;
+          *)
+            echo 'Invalid answer, exiting.' >&2
+            sleep 1
+            exit 1
+            ;;
+        esac
+      exit 1
+    fi
 
-  echo 'Disk is not in frozen state, we can continue.'
-  hdparm --user-master user --security-set-pass Pass "${target_disk}"
-  if ! hdparm -I "${target_disk}" | grep -P "Security level high" >&2; then
-    echo 'Failed setting user and password, exiting.' >&2
-    exit 1
-  fi
+    echo 'Disk is not in frozen state, we can continue.'
+    hdparm --user-master user --security-set-pass Pass "${target_disk}"
+    if ! hdparm -I "${target_disk}" | grep -P "Security level high" >&2; then
+      echo 'Failed setting user and password, exiting.' >&2
+      exit 1
+    fi
 
-  echo 'User and password set, ready for secure erase.'
-  hdparm --user-master user --security-erase Pass "${target_disk}"
-  echo 'Command completed. If you see no errors above, you may now reboot the device.'
+    echo 'User and password set, ready for secure erase.'
+    hdparm --user-master user --security-erase Pass "${target_disk}"
+    echo 'Command completed. If you see no errors above, you may now reboot the device.'
+    ;;
+  esac
 }
 
 secure_erase

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -16,8 +16,13 @@ secure_erase() {
     echo 'No disk selected, aborting!' >&2
     exit 1
   fi
-
+  
   echo "Chosen << ${target_disk} >>"
+  if udevadm info --query=all --name="${target_disk}" | grep 'ID_BUS=usb'; then
+    echo 'Selected disk is a USB device, I do not support them. Aborting..' >&2
+    exit 1
+  fi
+
   if ! hdparm -I "${target_disk}" | grep -P "SECURITY ERASE UNIT" >&2; then
     echo 'Selected disk does not support Secure Erase!' >&2
     exit 1
@@ -28,10 +33,10 @@ secure_erase() {
     echo 'Disk is in frozen state, aborting!' >&2
     echo 'Please close the lid of the device for a few seconds, reopen it and try again.' >&2
     echo
-    echo 'If we are netbooted, closing the lid will not put the device to sleep.'
-    echo 'We can however put it to sleep and wake it up with the usage of rtcwake.'
+    echo 'If we are netbooted, we can only put the device to sleep by running this command:'
+    echo 'echo -n mem > /sys/power/state'
     echo
-    read -p "Shall I run the command for you now? (y/n)[y] " gosleep
+    read -p "Shall I run the command for you? (y/n)[y] " gosleep
       case $gosleep in
         [yY]|"")
           echo 'Going to sleep now.'

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -5,7 +5,6 @@ set -eu
 ask_disk() {
   disks=$(awk '$4 ~ /^((md|mmcblk)[0-9]+|nvme[0-9]+n[0-9]+|[sv]d[a-z]|xvd[a-z])$/ {
                  print "/dev/"$4
-		 #print $4
                }' /proc/partitions)
   [ -n "$disks" ] || return 1
   printf %s "$disks" | fzf -1 --height=5 --layout=reverse-list
@@ -29,7 +28,7 @@ secure_erase() {
     echo 'Disk is in frozen state, aborting!' >&2
     echo 'Please close the lid of the device for a few seconds, reopen it and try again.' >&2
     echo
-    echo 'If we are netbooted, we can only put the device to sleep by issuing the following command:'
+    echo 'If we are netbooted, we can only put the device to sleep by running this command:'
     echo 'echo -n mem > /sys/power/state'
     echo
     read -p "Shall I run the command for you? (y/n)[y] " gosleep
@@ -40,12 +39,12 @@ secure_erase() {
           echo -n mem > /sys/power/state
           ;;
         [nN])
-          echo 'Not going to sleep. You must close the lid and reopen, or run the command by hand. Then retry.'
+          echo 'Not going to sleep. You must close and reopen the lid, or run the command by hand. Then retry.'
           sleep 1
           exit 1
           ;;
         *)
-          echo 'Invalid response, exiting.' >&2
+          echo 'Invalid answer, exiting.' >&2
           sleep 1
           exit 1
           ;;

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -eu
+
+ask_disk() {
+  disks=$(awk '$4 ~ /^((md|mmcblk)[0-9]+|nvme[0-9]+n[0-9]+|[sv]d[a-z]|xvd[a-z])$/ {
+                 print "/dev/"$4
+		 #print $4
+               }' /proc/partitions)
+  [ -n "$disks" ] || return 1
+  printf %s "$disks" | fzf -1 --height=5 --layout=reverse-list
+}
+
+secure_erase() {
+  echo 'Choose a disk to Secure Erase:'
+  if ! target_disk=$(ask_disk); then
+    echo 'No disk selected, aborting!' >&2
+    exit 1
+  fi
+
+  echo "Chosen << ${target_disk} >>"
+  if ! hdparm -I "${target_disk}" | grep -P "SECURITY ERASE UNIT" >&2; then
+    echo 'Selected disk does not support Secure Erase!'
+    exit 1
+  else
+    echo 'Disk supports Secure Erase.'
+    if ! hdparm -I "${target_disk}" | grep -P "not\tfrozen" >&2; then
+      echo 'Disk is in frozen state, aborting. Please close the lid of the device for a few seconds.'
+    else
+      echo 'Disk is not in frozen state, we can continue.'
+      hdparm --user-master user --security-set-pass Pass "${target_disk}"
+      if hdparm -I "${target_disk}" | grep -P "Security level high" >&2; then
+        echo 'User and password set, ready for secure erase.'
+	hdparm --user-master user --security-erase Pass "${target_disk}"
+        echo 'Command completed. If you see no errors above, you may now reboot the device.'
+      else
+        echo 'Failed setting user and password, exiting.'
+	exit 1
+      fi
+    fi
+  fi
+}
+
+secure_erase

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -16,7 +16,7 @@ secure_erase() {
     echo 'No disk selected, aborting!' >&2
     exit 1
   fi
-  
+
   echo "Chosen << ${target_disk} >>"
   if udevadm info --query=all --name="${target_disk}" | grep 'ID_BUS=usb'; then
     echo 'Selected disk is a USB device, I do not support them. Aborting..' >&2
@@ -33,10 +33,10 @@ secure_erase() {
     echo 'Disk is in frozen state, aborting!' >&2
     echo 'Please close the lid of the device for a few seconds, reopen it and try again.' >&2
     echo
-    echo 'If we are netbooted, we can only put the device to sleep by running this command:'
-    echo 'echo -n mem > /sys/power/state'
+    echo 'If we are netbooted, closing the lid will not put the device to sleep.'
+    echo 'We can however put it to sleep and wake it up with the usage of rtcwake.'
     echo
-    read -p "Shall I run the command for you? (y/n)[y] " gosleep
+    read -p "Shall I run the command for you now? (y/n)[y] " gosleep
       case $gosleep in
         [yY]|"")
           echo 'Going to sleep now.'

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -36,7 +36,7 @@ secure_erase() {
         [yY]|"")
           echo 'Going to sleep now.'
           sleep 1
-          echo -n mem > /sys/power/state
+	  rtcwake -m mem -s 5
           ;;
         [nN])
           echo 'Not going to sleep. You must close and reopen the lid, or run the command by hand. Then retry.'

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -36,7 +36,7 @@ secure_erase() {
         [yY]|"")
           echo 'Going to sleep now.'
           sleep 1
-	  rtcwake -m mem -s 5
+          rtcwake -m mem -s 5
           ;;
         [nN])
           echo 'Not going to sleep. You must close and reopen the lid, or run the command by hand. Then retry.'

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -28,6 +28,28 @@ secure_erase() {
   if ! hdparm -I "${target_disk}" | grep -P "not\tfrozen" >&2; then
     echo 'Disk is in frozen state, aborting!' >&2
     echo 'Please close the lid of the device for a few seconds, reopen it and try again.' >&2
+    echo
+    echo 'If we are netbooted, we can only put the device to sleep by issuing the following command:'
+    echo 'echo -n mem > /sys/power/state'
+    echo
+    read -p "Shall I run the command for you? (y/n)[y] " gosleep
+      case $gosleep in
+        [yY]|"")
+          echo 'Going to sleep now.'
+          sleep 1
+          echo -n mem > /sys/power/state
+          ;;
+        [nN])
+          echo 'Not going to sleep. You must close the lid and reopen, or run the command by hand. Then retry.'
+          sleep 1
+          exit 1
+          ;;
+        *)
+          echo 'Invalid response, exiting.' >&2
+          sleep 1
+          exit 1
+          ;;
+      esac
     exit 1
   fi
 

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -28,10 +28,10 @@ secure_erase() {
     echo 'Disk is in frozen state, aborting!' >&2
     echo 'Please close the lid of the device for a few seconds, reopen it and try again.' >&2
     echo
-    echo 'If we are netbooted, we can only put the device to sleep by running this command:'
-    echo 'echo -n mem > /sys/power/state'
+    echo 'If we are netbooted, closing the lid will not put the device to sleep.'
+    echo 'We can however put it to sleep and wake it up with the usage of rtcwake.'
     echo
-    read -p "Shall I run the command for you? (y/n)[y] " gosleep
+    read -p "Shall I run the command for you now? (y/n)[y] " gosleep
       case $gosleep in
         [yY]|"")
           echo 'Going to sleep now.'

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -21,7 +21,7 @@ secure_erase() {
   case "${target_disk}" in
     *nvme*)
       echo 'Selected disk is an NVMe disk. Using "nvme-cli" utility for Secure Erase.'
-      time nvme format -s1 "${target_disk}"
+      time --format "Time elapsed: %E" nvme format -s1 "${target_disk}"
       echo 'You may check how long the erase took above.'
       exit 1
       ;;
@@ -73,7 +73,7 @@ secure_erase() {
       fi
 
       echo 'User and password set, proceeding to Secure Erase.'
-      time hdparm --user-master user --security-erase Pass "${target_disk}"
+      time --format "Time elapsed: %E" hdparm --user-master user --security-erase Pass "${target_disk}"
       echo 'Command completed. You may check how long the erase took above.'
       echo 'If you see no errors, you may re-plug the disk or reboot the device.'
       ;;

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -20,7 +20,7 @@ secure_erase() {
   echo "Chosen << ${target_disk} >>"
   case "${target_disk}" in
     *nvme*)
-      echo 'Selected disk is an NVMe disk. Using nvme-cli utility...'
+      echo 'Selected disk is an NVMe disk. Using "nvme-cli" utility for Secure Erase.'
       nvme format -s1 "${target_disk}"
       exit 1
       ;;
@@ -30,14 +30,14 @@ secure_erase() {
         exit 1
       fi
 
-      if ! hdparm -I "${target_disk}" | grep -P "SECURITY ERASE UNIT" >&2; then
+      if ! hdparm -I "${target_disk}" | grep "SECURITY ERASE UNIT" >&2; then
         echo 'Selected disk does not support Secure Erase!' >&2
         exit 1
       fi
 
       echo 'Disk supports Secure Erase.'
-        if ! hdparm -I "${target_disk}" | grep -P "not\tfrozen" >&2; then
-        echo 'Disk is in frozen state, aborting!' >&2
+      if ! hdparm -I "${target_disk}" | grep -P "not\tfrozen" >&2; then
+        echo 'Disk is in frozen state, cannot continue!' >&2
         echo 'Please close the lid of the device for a few seconds, reopen it and try again.' >&2
         echo
         echo 'If we are netbooted, closing the lid will not put the device to sleep.'
@@ -61,20 +61,20 @@ secure_erase() {
             exit 1
             ;;
         esac
-      exit 1
-    fi
+        exit 1
+      fi
 
-    echo 'Disk is not in frozen state, we can continue.'
-    hdparm --user-master user --security-set-pass Pass "${target_disk}"
-    if ! hdparm -I "${target_disk}" | grep -P "Security level high" >&2; then
-      echo 'Failed setting user and password, exiting.' >&2
-      exit 1
-    fi
+      echo 'Disk is not in frozen state, we can continue.'
+      hdparm --user-master user --security-set-pass Pass "${target_disk}"
+      if ! hdparm -I "${target_disk}" | grep -P "Security level high" >&2; then
+        echo 'Failed setting user and password, exiting.' >&2
+        exit 1
+      fi
 
-    echo 'User and password set, ready for secure erase.'
-    hdparm --user-master user --security-erase Pass "${target_disk}"
-    echo 'Command completed. If you see no errors above, you may now reboot the device.'
-    ;;
+      echo 'User and password set, ready for secure erase.'
+      hdparm --user-master user --security-erase Pass "${target_disk}"
+      echo 'Command completed. If you see no errors above, you may now reboot the device.'
+      ;;
   esac
 }
 

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -75,6 +75,8 @@ secure_erase() {
       echo 'User and password set, proceeding to Secure Erase.'
       time --format "Time elapsed: %E" hdparm --user-master user --security-erase Pass "${target_disk}"
       echo 'Command completed. You may check how long the erase took above.'
+      echo 'Unlocking disk..'
+      hdparm --user-master user --security-unlock Pass "${target_disk}"
       echo 'If you see no errors, you may re-plug the disk or reboot the device.'
       ;;
   esac

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -20,25 +20,27 @@ secure_erase() {
 
   echo "Chosen << ${target_disk} >>"
   if ! hdparm -I "${target_disk}" | grep -P "SECURITY ERASE UNIT" >&2; then
-    echo 'Selected disk does not support Secure Erase!'
+    echo 'Selected disk does not support Secure Erase!' >&2
     exit 1
-  else
-    echo 'Disk supports Secure Erase.'
-    if ! hdparm -I "${target_disk}" | grep -P "not\tfrozen" >&2; then
-      echo 'Disk is in frozen state, aborting. Please close the lid of the device for a few seconds.'
-    else
-      echo 'Disk is not in frozen state, we can continue.'
-      hdparm --user-master user --security-set-pass Pass "${target_disk}"
-      if hdparm -I "${target_disk}" | grep -P "Security level high" >&2; then
-        echo 'User and password set, ready for secure erase.'
-	hdparm --user-master user --security-erase Pass "${target_disk}"
-        echo 'Command completed. If you see no errors above, you may now reboot the device.'
-      else
-        echo 'Failed setting user and password, exiting.'
-	exit 1
-      fi
-    fi
   fi
+
+  echo 'Disk supports Secure Erase.'
+  if ! hdparm -I "${target_disk}" | grep -P "not\tfrozen" >&2; then
+    echo 'Disk is in frozen state, aborting!' >&2
+    echo 'Please close the lid of the device for a few seconds, reopen it and try again.' >&2
+    exit 1
+  fi
+
+  echo 'Disk is not in frozen state, we can continue.'
+  hdparm --user-master user --security-set-pass Pass "${target_disk}"
+  if ! hdparm -I "${target_disk}" | grep -P "Security level high" >&2; then
+    echo 'Failed setting user and password, exiting.' >&2
+    exit 1
+  fi
+
+  echo 'User and password set, ready for secure erase.'
+  hdparm --user-master user --security-erase Pass "${target_disk}"
+  echo 'Command completed. If you see no errors above, you may now reboot the device.'
 }
 
 secure_erase


### PR DESCRIPTION
The basic idea for this is to quickly erase disks from netboot and the user enviroment without much typing.

Master username and master password are hardcoded, but shouldn't pose a problem as they are temporary and are gone completely after the erase is completed. Still, they must be defined for secure erase to work.