### PR TITLE
'puavo-disk-erase' and 'puavo-bios-config' improvements

### DIFF
--- a/parts/ltsp/puavo-install/puavo-bios-config
+++ b/parts/ltsp/puavo-install/puavo-bios-config
@@ -45,13 +45,14 @@ import_config_usb_stick_factory() {
 }
 
 ask_choice() {
-  choices=$(cat <<'EOF')
+  choices=$(cat <<'EOF'
 Flash latest BIOS (HP)
 Import Student laptop BIOS Config
 Import USB Stick factory BIOS Config
 use HP BIOS utilities
 exit
 EOF
+)
   printf "%s" "$choices" | fzf --height=7 --layout=reverse-list
 }
 

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -67,7 +67,7 @@ secure_erase() {
 
       echo 'Disk is not in frozen state, we can continue.'
       hdparm --user-master user --security-set-pass Pass "${target_disk}"
-      if ! hdparm -I "${target_disk}" | grep -P "Security level high" >&2; then
+      if ! hdparm -I "${target_disk}" | grep "Security level high" >&2; then
         echo 'Failed setting user and password, exiting.' >&2
         exit 1
       fi
@@ -75,8 +75,12 @@ secure_erase() {
       echo 'User and password set, proceeding to Secure Erase.'
       time --format "Time elapsed: %E" hdparm --user-master user --security-erase Pass "${target_disk}"
       echo 'Command completed. You may check how long the erase took above.'
-      echo 'Unlocking disk..'
-      hdparm --user-master user --security-unlock Pass "${target_disk}"
+
+      if ! hdparm -I "${target_disk}" | grep -P "not\tlocked"; then
+        echo 'Unlocking disk..'
+        hdparm --user-master user --security-unlock Pass "${target_disk}"
+      fi
+
       echo 'If you see no errors, you may re-plug the disk or reboot the device.'
       ;;
   esac

--- a/parts/ltsp/puavo-install/puavo-disk-erase
+++ b/parts/ltsp/puavo-install/puavo-disk-erase
@@ -23,7 +23,8 @@ secure_erase() {
       echo 'Selected disk is an NVMe disk. Using "nvme-cli" utility for Secure Erase.'
       time --format "Time elapsed: %E" nvme format -s1 "${target_disk}"
       echo 'You may check how long the erase took above.'
-      exit 1
+      echo 
+      sleep 2
       ;;
     *)
       if udevadm info --query=all --name="${target_disk}" | grep 'ID_BUS=usb'; then
@@ -62,7 +63,6 @@ secure_erase() {
             exit 1
             ;;
         esac
-        exit 1
       fi
 
       echo 'Disk is not in frozen state, we can continue.'
@@ -77,11 +77,12 @@ secure_erase() {
       echo 'Command completed. You may check how long the erase took above.'
 
       if ! hdparm -I "${target_disk}" | grep -P "not\tlocked"; then
-        echo 'Unlocking disk..'
+        echo 'Disk seems to be locked after erase. Unlocking now.'
         hdparm --user-master user --security-unlock Pass "${target_disk}"
       fi
 
       echo 'If you see no errors, you may re-plug the disk or reboot the device.'
+      echo 
       ;;
   esac
 }


### PR DESCRIPTION
'puavo-bios-config':
  - Fix syntax for choice menu so it works on bullseye.

'puavo-disk-erase':
  - Removed a couple unnecessary exits.
  - More descriptive message when unlocking disk.
  - Removed unnecessary regexp flag from a grep.

These were tested by me, especially puavo-disk-erase changes were tested a lot. Feedback welcome.