### PR TITLE
Fix Bluetooth service startup and BT connections on Bookworm.

### DIFF
--- a/rules/bluetoothservice/files/bluetooth_override.conf
+++ b/rules/bluetoothservice/files/bluetooth_override.conf
@@ -1,0 +1,3 @@
+[Service]
+StateDirectory=
+ReadWritePaths=/var/lib/bluetooth/

--- a/rules/bluetoothservice/manifests/init.pp
+++ b/rules/bluetoothservice/manifests/init.pp
@@ -1,0 +1,12 @@
+class bluetoothservice {
+  # Systemd fails to start bluetooth service because StateDirectory is symlinked at '/state'.
+  # So lets override 'StateDirectory' value.
+
+  file {
+    '/etc/systemd/system/bluetooth.service.d':
+      ensure => directory;
+
+    '/etc/systemd/system/bluetooth.service.d/bluetooth_override.conf':
+      source => 'puppet:///modules/bluetoothservice/bluetooth_override.conf';
+  }
+}

--- a/rules/image/manifests/bundle/desktop.pp
+++ b/rules/image/manifests/bundle/desktop.pp
@@ -2,6 +2,7 @@ class image::bundle::desktop {
   include ::accountsservice
   include ::autostart
   include ::blueman
+  include ::bluetoothservice
   include ::chromium
   include ::desktop
   include ::desktop_cups


### PR DESCRIPTION
Startup problem was due to "StateDirectory" being a link.
Device connection fix was adding '/var/lib/bluetooth/' to "ReadWritePaths".