### PR TITLE
Fix smoketest test user removal.

### DIFF
--- a/parts/ltsp/ruby-puavobs/puavobs.rb
+++ b/parts/ltsp/ruby-puavobs/puavobs.rb
@@ -204,7 +204,7 @@ module PuavoBS
   def self.remove_user(admin_username, admin_password, user_username)
     user_id = self.get_user_id(admin_username, admin_password, user_username)
 
-    url = self.get_api_url("/v3/users/#{ user_username }/mark_for_deletion")
+    url = self.get_api_url("/v3/users/#{ user_username }")
     response = HTTP
       .auth(self.basic_auth(admin_username, admin_password))
       .delete(url)


### PR DESCRIPTION
Apparently hasn't worked since changes in Feb 2020. The previous code just removed any marked-for-removal tag. The test users are something that we want to get rid of right away, so use full delete call.

Quick RFC as we are dealing here with removing user accounts.