### PR TITLE
puavo-laptop-setup: factory reset progress dialog

### DIFF
--- a/parts/laptop-setup/Makefile
+++ b/parts/laptop-setup/Makefile
@@ -10,8 +10,8 @@ INSTALL_DATA = $(INSTALL) -m 644
 .PHONY: all
 all: po/de/puavo-laptop-setup.mo po/fi/puavo-laptop-setup.mo po/sv/puavo-laptop-setup.mo
 
-po/puavo-laptop-setup.pot: puavo-laptop-setup
-	xgettext --omit-header --language python --keyword=_tr -o $@ $^
+po/puavo-laptop-setup.pot: puavo-laptop-setup puavo-laptop-setup.glade
+	xgettext --omit-header --language python --keyword=_tr -o $@ puavo-laptop-setup
 	xgettext -j --omit-header --language Glade -o po/puavo-laptop-setup.pot puavo-laptop-setup.glade
 
 %.po: po/puavo-laptop-setup.pot

--- a/parts/laptop-setup/po/de/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/de/puavo-laptop-setup.po
@@ -9,7 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: puavo-laptop-setup:257
+#: puavo-laptop-setup:259
 msgid ""
 "It is now possible to choose Windows from the boot menu when starting up the "
 "computer."
@@ -17,7 +17,7 @@ msgstr ""
 "Es ist jetzt möglich Windows beim Startmenü wählen. Das Menü wird kurz nach "
 "dem Einschalten von dem Computer gezeigt."
 
-#: puavo-laptop-setup:261
+#: puavo-laptop-setup:263
 msgid ""
 "Abitti-compatible eExam-system is not updated when running Windows, you have "
 "to boot into the current system to update it."
@@ -26,15 +26,15 @@ msgstr ""
 "bei Windows-Betriebssystem. Sie müssen zu diesem laufenden Betriebssystem "
 "booten um auch das Testsystem zu aktualisieren."
 
-#: puavo-laptop-setup:378
+#: puavo-laptop-setup:405
 msgid "error saving changes"
 msgstr "Fehler beim Speichern der Veränderungen"
 
-#: puavo-laptop-setup:401
+#: puavo-laptop-setup:428
 msgid "DANGER! DANGER!"
 msgstr "GEFAHR! GEFAHR!"
 
-#: puavo-laptop-setup:403
+#: puavo-laptop-setup:430
 msgid ""
 "THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!  IT WILL DESTROY "
 "ALL YOUR DATA IN YOUR HOME DIRECTORY, AND MORE!  WHEN IN DOUBT, TURN OFF THE "
@@ -46,65 +46,104 @@ msgstr ""
 "ZÖGERN - BITTE DEN COMPUTER ZU MACHEN UND WEG RENNEN! (Bitte OK drücken und "
 "Passwort eingeben, wenn Sie jedoch das machen wollen)"
 
-#: puavo-laptop-setup:430 puavo-laptop-setup:446
+#: puavo-laptop-setup:453
+msgid "Factory reset is running step"
+msgstr ""
+
+#: puavo-laptop-setup:466
+msgid "Factory reset is running"
+msgstr ""
+
+#: puavo-laptop-setup:474
+msgid "Failed to start factory reset"
+msgstr ""
+
+#: puavo-laptop-setup:477 puavo-laptop-setup:505
+msgid "Factory reset failed"
+msgstr ""
+
+#: puavo-laptop-setup:495
+msgid ""
+"Factory reset succeeded. The system is going to reboot in few seconds..."
+msgstr ""
+
+#: puavo-laptop-setup:507
+msgid ""
+"Further details can be found from the factory reset log. Please contact "
+"support for assistance."
+msgstr ""
+
+#: puavo-laptop-setup:572 puavo-laptop-setup:602
 msgid "Laptop setup"
 msgstr "Laptop Einstellungen"
 
-#: puavo-laptop-setup:436
+#: puavo-laptop-setup:592
 msgid "You do not have the required permissions to use this tool."
 msgstr "Sie haben nicht ausreichende Rechte um dieses Werkzeug zu verwenden"
 
-#: puavo-laptop-setup:446
+#: puavo-laptop-setup:602
 msgid "is already running"
 msgstr "schon im Gang"
 
-#: puavo-laptop-setup.glade:22
+#: puavo-laptop-setup.glade:20 puavo-laptop-setup.glade:30
 msgid "eExam-system version (Abitti-compatible)"
 msgstr "Version des elektronischen Testsystems  (Abitti-kompatibel)"
 
-#: puavo-laptop-setup.glade:33
+#: puavo-laptop-setup.glade:41
 msgid "Show developer mode in boot menu"
 msgstr "Entwicklungsmodus beim Startmenü zeigen"
 
-#: puavo-laptop-setup.glade:44
+#: puavo-laptop-setup.glade:52
 msgid "Default operating system at boot"
 msgstr "Standardbetriebssystem beim Starten"
 
-#: puavo-laptop-setup.glade:58
+#: puavo-laptop-setup.glade:66
 msgid "latest version"
 msgstr "Die letzte version"
 
-#: puavo-laptop-setup.glade:74
+#: puavo-laptop-setup.glade:82
 msgid "school version"
 msgstr "Schulversion"
 
-#: puavo-laptop-setup.glade:91
+#: puavo-laptop-setup.glade:99
 msgid "this version:"
 msgstr "Diese Version:"
 
-#: puavo-laptop-setup.glade:127
+#: puavo-laptop-setup.glade:144
 msgid "Puavo OS (Linux)"
 msgstr "Puavo OS (Linux)"
 
-#: puavo-laptop-setup.glade:143
+#: puavo-laptop-setup.glade:160
 msgid "eExam-system"
 msgstr "Elektronisches Test-System (Abitti)"
 
-#: puavo-laptop-setup.glade:159
+#: puavo-laptop-setup.glade:176
 msgid "Windows"
 msgstr "Windows"
 
 # from puavo-laptop-setup.glade
-#: puavo-laptop-setup.glade:195
+#: puavo-laptop-setup.glade:212
 msgid "Start using Windows"
 msgstr "Windows aktivieren"
 
-#: puavo-laptop-setup.glade:214
+#: puavo-laptop-setup.glade:231
 msgid ""
 "Destroy all user data and reset laptop to factory state (requires password)"
 msgstr ""
 "Alle Benutzerdaten löschen und das System zu Werkseinstellungen "
 "zurücksetzen. (Passwort erforderlich)"
+
+#: puavo-laptop-setup.glade:257
+msgid "Factory reset"
+msgstr ""
+
+#: puavo-laptop-setup.glade:272
+msgid "Close"
+msgstr ""
+
+#: puavo-laptop-setup.glade:317
+msgid "Factory reset log"
+msgstr ""
 
 #~ msgid "latest"
 #~ msgstr "letzte"

--- a/parts/laptop-setup/po/de/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/de/puavo-laptop-setup.po
@@ -48,30 +48,30 @@ msgstr ""
 
 #: puavo-laptop-setup:453
 msgid "Factory reset is running step"
-msgstr ""
+msgstr "Das Zurücksetzen der Werkseinstellungen Schritt"
 
 #: puavo-laptop-setup:466
 msgid "Factory reset is running"
-msgstr ""
+msgstr "Das Zurücksetzen der Werkseinstellungen wird durchgeführt"
 
 #: puavo-laptop-setup:474
 msgid "Failed to start factory reset"
-msgstr ""
+msgstr "Das Zurücksetzen der Werkseinstellungen konnte nicht gestartet werden"
 
 #: puavo-laptop-setup:477 puavo-laptop-setup:505
 msgid "Factory reset failed"
-msgstr ""
+msgstr "Das Zurücksetzen der Werkseinstellungen ist gescheitert"
 
 #: puavo-laptop-setup:495
 msgid ""
 "Factory reset succeeded. The system is going to reboot in few seconds..."
-msgstr ""
+msgstr "Das Zurücksetzen der Werkseinstellungen ist gefolgt. Das System wird in einigen Sekunden neugestartet."
 
 #: puavo-laptop-setup:507
 msgid ""
 "Further details can be found from the factory reset log. Please contact "
 "support for assistance."
-msgstr ""
+msgstr "Weitere Informationen können aus der Werkseinstellungslog gelesen werden. Bitte Kontakt mit Helpdesk aufnehmen."
 
 #: puavo-laptop-setup:572 puavo-laptop-setup:602
 msgid "Laptop setup"
@@ -135,15 +135,15 @@ msgstr ""
 
 #: puavo-laptop-setup.glade:257
 msgid "Factory reset"
-msgstr ""
+msgstr "Das Zurücksetzen der Werkseinstellungen"
 
 #: puavo-laptop-setup.glade:272
 msgid "Close"
-msgstr ""
+msgstr "Schließen"
 
 #: puavo-laptop-setup.glade:317
 msgid "Factory reset log"
-msgstr ""
+msgstr "Protokoll zum Zurücksetzen der Werkseinstellungen"
 
 #~ msgid "latest"
 #~ msgstr "letzte"

--- a/parts/laptop-setup/po/fi/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/fi/puavo-laptop-setup.po
@@ -9,7 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: puavo-laptop-setup:257
+#: puavo-laptop-setup:259
 msgid ""
 "It is now possible to choose Windows from the boot menu when starting up the "
 "computer."
@@ -18,7 +18,7 @@ msgstr ""
 "käynnistysvalikkoon. Käynnistysvalikko tulee näkyviin aina tietokoneen "
 "uudelleen käynnistyksen yhteydessä."
 
-#: puavo-laptop-setup:261
+#: puavo-laptop-setup:263
 msgid ""
 "Abitti-compatible eExam-system is not updated when running Windows, you have "
 "to boot into the current system to update it."
@@ -29,15 +29,15 @@ msgstr ""
 "käynnistyksen yhteydessä 'Normaali käynnistys' ja käynnistää tähän nyt "
 "käytössä olevaan Opinsys OS -käyttöjärjestelmään."
 
-#: puavo-laptop-setup:378
+#: puavo-laptop-setup:405
 msgid "error saving changes"
 msgstr "virhe tallennuksessa"
 
-#: puavo-laptop-setup:401
+#: puavo-laptop-setup:428
 msgid "DANGER! DANGER!"
 msgstr "VAARA! VAARA!"
 
-#: puavo-laptop-setup:403
+#: puavo-laptop-setup:430
 msgid ""
 "THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!  IT WILL DESTROY "
 "ALL YOUR DATA IN YOUR HOME DIRECTORY, AND MORE!  WHEN IN DOUBT, TURN OFF THE "
@@ -49,64 +49,107 @@ msgstr ""
 "SAMMUTA KONE, PANIKOI JA JUOKSE KARKUUN! (paina OK ja anna salasanasi jos "
 "haluat kuitenkin tehdä tämän.)"
 
-#: puavo-laptop-setup:430 puavo-laptop-setup:446
+#: puavo-laptop-setup:453
+msgid "Factory reset is running step"
+msgstr "Tehdasasetusten palautus on käynnissä vaiheessa"
+
+#: puavo-laptop-setup:466
+msgid "Factory reset is running"
+msgstr "Tehdasasetusten palautus on käynnissä"
+
+#: puavo-laptop-setup:474
+msgid "Failed to start factory reset"
+msgstr "Tehdasasetusten palautuksen käynnistys epäonnistui"
+
+#: puavo-laptop-setup:477 puavo-laptop-setup:505
+msgid "Factory reset failed"
+msgstr "Tehdasasetusten palautus epäonnistui"
+
+#: puavo-laptop-setup:495
+msgid ""
+"Factory reset succeeded. The system is going to reboot in few seconds..."
+msgstr ""
+"Tehdasasetusten palautus onnistui. Järjestelmä käynnistyy uudestaan muutaman "
+"sekunnin kuluessa..."
+
+#: puavo-laptop-setup:507
+msgid ""
+"Further details can be found from the factory reset log. Please contact "
+"support for assistance."
+msgstr ""
+"Tarkemmat tiedot virheestä löytyvät tehdasasetusten palautuslokista. Olkaa "
+"hyvä ja ottakaa yhteyttä tukeen ongelman selvittämiseksi."
+
+#: puavo-laptop-setup:572 puavo-laptop-setup:602
 msgid "Laptop setup"
 msgstr "Kannettavan asetukset"
 
-#: puavo-laptop-setup:436
+#: puavo-laptop-setup:592
 msgid "You do not have the required permissions to use this tool."
 msgstr "Sinulla ei ole tarvittavia oikeuksia tämän työkalun käyttöön."
 
-#: puavo-laptop-setup:446
+#: puavo-laptop-setup:602
 msgid "is already running"
 msgstr "on jo käynnissä"
 
-#: puavo-laptop-setup.glade:22
+#: puavo-laptop-setup.glade:20 puavo-laptop-setup.glade:30
 msgid "eExam-system version (Abitti-compatible)"
 msgstr "Koejärjestelmäversio (Abitti-yhteensopiva)"
 
-#: puavo-laptop-setup.glade:33
+#: puavo-laptop-setup.glade:41
 msgid "Show developer mode in boot menu"
 msgstr "Näytä kehittäjätila tietokonetta käynnistettäessä"
 
-#: puavo-laptop-setup.glade:44
+#: puavo-laptop-setup.glade:52
 msgid "Default operating system at boot"
 msgstr "Oletuksena käynnistettävä järjestelmä"
 
-#: puavo-laptop-setup.glade:58
+#: puavo-laptop-setup.glade:66
 msgid "latest version"
 msgstr "viimeisin versio"
 
-#: puavo-laptop-setup.glade:74
+#: puavo-laptop-setup.glade:82
 msgid "school version"
 msgstr "koulun versio"
 
-#: puavo-laptop-setup.glade:91
+#: puavo-laptop-setup.glade:99
 msgid "this version:"
 msgstr "tämä versio:"
 
-#: puavo-laptop-setup.glade:127
+#: puavo-laptop-setup.glade:144
 msgid "Puavo OS (Linux)"
 msgstr ""
 
-#: puavo-laptop-setup.glade:143
+#: puavo-laptop-setup.glade:160
 msgid "eExam-system"
 msgstr "Koejärjestelmä"
 
-#: puavo-laptop-setup.glade:159
+#: puavo-laptop-setup.glade:176
 msgid "Windows"
 msgstr ""
 
 # from puavo-laptop-setup.glade
-#: puavo-laptop-setup.glade:195
+#: puavo-laptop-setup.glade:212
 msgid "Start using Windows"
 msgstr "Ota Windows käyttöön"
 
-#: puavo-laptop-setup.glade:214
+#: puavo-laptop-setup.glade:231
 msgid ""
 "Destroy all user data and reset laptop to factory state (requires password)"
 msgstr ""
 "Tuhoa kaikki tiedot ja palauta tietokone tehdastilaan (vaatii salasanan)"
+
+#: puavo-laptop-setup.glade:257
+msgid "Factory reset"
+msgstr "Tehdasasetusten palautus"
+
+#: puavo-laptop-setup.glade:272
+msgid "Close"
+msgstr "Sulje"
+
+#: puavo-laptop-setup.glade:317
+msgid "Factory reset log"
+msgstr "Tehdaasetusten palautusloki"
 
 #~ msgid "latest"
 #~ msgstr "viimeisin"

--- a/parts/laptop-setup/po/sv/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/sv/puavo-laptop-setup.po
@@ -9,7 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: puavo-laptop-setup:257
+#: puavo-laptop-setup:259
 msgid ""
 "It is now possible to choose Windows from the boot menu when starting up the "
 "computer."
@@ -17,7 +17,7 @@ msgstr ""
 "Windows har nu tilläggats till startmenun. Menun syns alltid när man startar "
 "om datorn."
 
-#: puavo-laptop-setup:261
+#: puavo-laptop-setup:263
 msgid ""
 "Abitti-compatible eExam-system is not updated when running Windows, you have "
 "to boot into the current system to update it."
@@ -26,15 +26,15 @@ msgstr ""
 "till Windows. För att byta / uppdatera din laptops Abitti-system måste man "
 "välja normal start och välja det här Opinsys Os som används nu. "
 
-#: puavo-laptop-setup:378
+#: puavo-laptop-setup:405
 msgid "error saving changes"
 msgstr "fel i sparning av ändringarna "
 
-#: puavo-laptop-setup:401
+#: puavo-laptop-setup:428
 msgid "DANGER! DANGER!"
 msgstr "FARA! FARA!"
 
-#: puavo-laptop-setup:403
+#: puavo-laptop-setup:430
 msgid ""
 "THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!  IT WILL DESTROY "
 "ALL YOUR DATA IN YOUR HOME DIRECTORY, AND MORE!  WHEN IN DOUBT, TURN OFF THE "
@@ -46,65 +46,104 @@ msgstr ""
 "OM DU TVIVLAR - STÄNG DATOR, GÅ I PANIK OCH SPRING BORT! (Tryck OK och ge "
 "ditt lösenord om du ändå vill göra det här.)"
 
-#: puavo-laptop-setup:430 puavo-laptop-setup:446
+#: puavo-laptop-setup:453
+msgid "Factory reset is running step"
+msgstr ""
+
+#: puavo-laptop-setup:466
+msgid "Factory reset is running"
+msgstr ""
+
+#: puavo-laptop-setup:474
+msgid "Failed to start factory reset"
+msgstr ""
+
+#: puavo-laptop-setup:477 puavo-laptop-setup:505
+msgid "Factory reset failed"
+msgstr ""
+
+#: puavo-laptop-setup:495
+msgid ""
+"Factory reset succeeded. The system is going to reboot in few seconds..."
+msgstr ""
+
+#: puavo-laptop-setup:507
+msgid ""
+"Further details can be found from the factory reset log. Please contact "
+"support for assistance."
+msgstr ""
+
+#: puavo-laptop-setup:572 puavo-laptop-setup:602
 msgid "Laptop setup"
 msgstr "Laptop inställningar"
 
-#: puavo-laptop-setup:436
+#: puavo-laptop-setup:592
 msgid "You do not have the required permissions to use this tool."
 msgstr "Du har inte tillräckliga rättigheter att använda verktyget."
 
-#: puavo-laptop-setup:446
+#: puavo-laptop-setup:602
 msgid "is already running"
 msgstr "är redan igång"
 
-#: puavo-laptop-setup.glade:22
+#: puavo-laptop-setup.glade:20 puavo-laptop-setup.glade:30
 msgid "eExam-system version (Abitti-compatible)"
 msgstr "eProv-systemversion (Abitti-kompatibel)"
 
-#: puavo-laptop-setup.glade:33
+#: puavo-laptop-setup.glade:41
 msgid "Show developer mode in boot menu"
 msgstr "Visa utvecklarläge i startmenyn"
 
-#: puavo-laptop-setup.glade:44
+#: puavo-laptop-setup.glade:52
 msgid "Default operating system at boot"
 msgstr "Standardoperativsystem i starten"
 
-#: puavo-laptop-setup.glade:58
+#: puavo-laptop-setup.glade:66
 msgid "latest version"
 msgstr "den senaste versionen"
 
-#: puavo-laptop-setup.glade:74
+#: puavo-laptop-setup.glade:82
 msgid "school version"
 msgstr "skolversion"
 
-#: puavo-laptop-setup.glade:91
+#: puavo-laptop-setup.glade:99
 msgid "this version:"
 msgstr "den här versionen:"
 
-#: puavo-laptop-setup.glade:127
+#: puavo-laptop-setup.glade:144
 msgid "Puavo OS (Linux)"
 msgstr "Puavo OS (Linux)"
 
-#: puavo-laptop-setup.glade:143
+#: puavo-laptop-setup.glade:160
 msgid "eExam-system"
 msgstr "eProv-system Abitti"
 
-#: puavo-laptop-setup.glade:159
+#: puavo-laptop-setup.glade:176
 msgid "Windows"
 msgstr "Windows"
 
 # from puavo-laptop-setup.glade
-#: puavo-laptop-setup.glade:195
+#: puavo-laptop-setup.glade:212
 msgid "Start using Windows"
 msgstr "Aktivera Windows"
 
-#: puavo-laptop-setup.glade:214
+#: puavo-laptop-setup.glade:231
 msgid ""
 "Destroy all user data and reset laptop to factory state (requires password)"
 msgstr ""
 "Förstör all data och återställ datorn till fabriksinställningarna (kräver "
 "lösenord)"
+
+#: puavo-laptop-setup.glade:257
+msgid "Factory reset"
+msgstr ""
+
+#: puavo-laptop-setup.glade:272
+msgid "Close"
+msgstr ""
+
+#: puavo-laptop-setup.glade:317
+msgid "Factory reset log"
+msgstr ""
 
 #~ msgid "latest"
 #~ msgstr "senast"

--- a/parts/laptop-setup/po/sv/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/sv/puavo-laptop-setup.po
@@ -48,30 +48,30 @@ msgstr ""
 
 #: puavo-laptop-setup:453
 msgid "Factory reset is running step"
-msgstr ""
+msgstr "Fabriksåterställning kör steg"
 
 #: puavo-laptop-setup:466
 msgid "Factory reset is running"
-msgstr ""
+msgstr "Fabriksåterställning pågår"
 
 #: puavo-laptop-setup:474
 msgid "Failed to start factory reset"
-msgstr ""
+msgstr "Fabriksåterställningen kunde inte börjas"
 
 #: puavo-laptop-setup:477 puavo-laptop-setup:505
 msgid "Factory reset failed"
-msgstr ""
+msgstr "Fabriksåterställningen mislyckades"
 
 #: puavo-laptop-setup:495
 msgid ""
 "Factory reset succeeded. The system is going to reboot in few seconds..."
-msgstr ""
+msgstr "Fabriksåterställningen lyckades. Systemet startar om i några sekunder..."
 
 #: puavo-laptop-setup:507
 msgid ""
 "Further details can be found from the factory reset log. Please contact "
 "support for assistance."
-msgstr ""
+msgstr "Ytterligare detaljer kan hittas från fabriksåterställningsloggen. Kontakta supporten för hjälp."
 
 #: puavo-laptop-setup:572 puavo-laptop-setup:602
 msgid "Laptop setup"
@@ -135,15 +135,15 @@ msgstr ""
 
 #: puavo-laptop-setup.glade:257
 msgid "Factory reset"
-msgstr ""
+msgstr "Fabriksåterställning"
 
 #: puavo-laptop-setup.glade:272
 msgid "Close"
-msgstr ""
+msgstr "Stäng"
 
 #: puavo-laptop-setup.glade:317
 msgid "Factory reset log"
-msgstr ""
+msgstr "Fabriksåterställningslogg"
 
 #~ msgid "latest"
 #~ msgstr "senast"

--- a/parts/laptop-setup/puavo-laptop-setup
+++ b/parts/laptop-setup/puavo-laptop-setup
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import sys
+import threading
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import GLib, GObject, Gtk
@@ -439,13 +440,128 @@ class PuavoLaptopSetup:
 
 
     def run_reset_to_factory_settings(self):
-        # how to handle error codes or anything?
-        # maybe some progress bar should be shown... ?
-        cmd = [ 'pkexec',
-                '/usr/sbin/puavo-reset-laptop-to-factory-defaults',
-                '--force' ]
-        subprocess.call(cmd)
+        factory_reset_text_view = builder.get_object('factory_reset_text_view')
+        factory_reset_status_bar = builder.get_object('factory_reset_status_bar')
+        factory_reset_text_buffer = Gtk.TextBuffer()
+        factory_reset_text_view.set_buffer(factory_reset_text_buffer)
+        context_id = factory_reset_status_bar.get_context_id('progress')
 
+        def text_buffer_write(line):
+            step_log_line_match = re.match(r'^> info: step (\d+/\d+)$', line)
+            if step_log_line_match is not None:
+                steps = step_log_line_match.group(1)
+                text = _tr('Factory reset is running step')
+                status_message = f"{text} {steps}..."
+                factory_reset_status_bar.push(context_id, status_message)
+
+            factory_reset_text_buffer.insert_at_cursor(line)
+
+            return False
+
+        def text_view_scroll_to_bottom():
+            factory_reset_text_view.scroll_mark_onscreen(factory_reset_text_buffer.get_insert())
+            return False
+
+        def on_cmd_start():
+            status_message = _tr('Factory reset is running')
+            factory_reset_status_bar.push(context_id, f"{status_message}...")
+
+            return False
+
+        def on_cmd_start_error(exception):
+            factory_reset_dialog.set_deletable(True)
+            factory_reset_dialog_button.set_sensitive(True)
+            status_message = _tr('Failed to start factory reset')
+            factory_reset_status_bar.push(context_id, f"{status_message}.")
+            text_buffer_write(str(exception))
+            dialog_title = _tr('Factory reset failed')
+            dialog = Gtk.MessageDialog(
+                parent=factory_reset_dialog,
+                title=f"{dialog_title}!",
+                flags=0,
+                message_type=Gtk.MessageType.ERROR,
+                buttons=Gtk.ButtonsType.OK,
+                text=f"{status_message}.",
+            )
+            dialog.run()
+            dialog.destroy()
+
+            return False
+
+        def on_cmd_exit(returnvalue):
+            factory_reset_dialog.set_deletable(True)
+            factory_reset_dialog_button.set_sensitive(True)
+            if returnvalue == 0:
+                text = _tr('Factory reset succeeded. The system is going to reboot in few seconds...')
+                factory_reset_status_bar.push(context_id, text)
+                dialog = Gtk.MessageDialog(
+                    parent=factory_reset_dialog,
+                    flags=0,
+                    message_type=Gtk.MessageType.INFO,
+                    buttons=Gtk.ButtonsType.OK,
+                    text=text,
+                )
+            else:
+                status_message = _tr('Factory reset failed')
+                factory_reset_status_bar.push(context_id, f"{status_message}.")
+                help_message = _tr('Further details can be found from the factory reset log. Please contact support for assistance.')
+                dialog = Gtk.MessageDialog(
+                    parent=factory_reset_dialog,
+                    flags=0,
+                    message_type=Gtk.MessageType.ERROR,
+                    buttons=Gtk.ButtonsType.OK,
+                    text=f"{status_message}. {help_message}",
+                )
+            dialog.run()
+            dialog.destroy()
+
+            return False
+
+        def run_cmd():
+            cmd = [ 'pkexec',
+                    '/usr/sbin/puavo-reset-laptop-to-factory-defaults',
+                    '--force' ]
+
+            cmd_process = None
+            try:
+                cmd_process = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, text=True)
+            except Exception as e:
+                GLib.idle_add(on_cmd_start_error, e)
+            else:
+                GLib.idle_add(on_cmd_start)
+                cmd_process.stdout.reconfigure(line_buffering=True)
+
+                for line in cmd_process.stdout:
+                    GLib.idle_add(text_buffer_write, line)
+
+                GLib.idle_add(text_view_scroll_to_bottom)
+            finally:
+                if cmd_process is not None:
+                    ## Wait forever? Killing
+                    ## puavo-reset-latop-to-factory-defaults might lead to
+                    ## a corrupt system.
+                    returncode = cmd_process.wait()
+                    GLib.idle_add(on_cmd_exit, returncode)
+
+        thread = threading.Thread(target=run_cmd, daemon=True)
+        thread.start()
+        factory_reset_dialog.run()
+        factory_reset_dialog.hide()
+
+def on_factory_reset_dialog_delete_event(dialog, event):
+    # We don't want to destroy the factory reset dialog because the
+    # user might re-enter or retry it. The dialog is created by
+    # builder only once.
+
+    # The other way would be to actually destroy them, but then
+    # recreating would mean we would need to create a new builder each
+    # time the dialog is shown. See
+    # https://discourse.gnome.org/t/cannot-reopen-dialog-after-closed-with-x-if-using-gtkbuilder-for-construction/7019
+    #
+    # I thing hiding is fine. Recreating builder and new dialog each
+    # time seems unncessary waste of resources.
+    dialog.hide()
+    return True
 
 builder = Gtk.Builder()
 builder.set_translation_domain('puavo-laptop-setup')
@@ -455,6 +571,20 @@ app_window = builder.get_object('app_window')
 app_window.set_icon_name('drive-harddisk-system')
 app_window.set_title(_tr('Laptop setup'))
 app_window.connect('destroy', Gtk.main_quit)
+
+factory_reset_dialog = builder.get_object('factory_reset_dialog')
+factory_reset_dialog.connect('delete-event', on_factory_reset_dialog_delete_event)
+factory_reset_dialog.set_size_request(800, 400)
+
+factory_reset_dialog_button = builder.get_object('factory_reset_dialog_button')
+## I could figure it out how in earth this should be done with Glade
+## for GtkDialog. Some googling seems to indicate that there should be
+## "Response ID" etc. available and setting it should connect the
+## button signal automatically to dialog.response with that response
+## ID, but nope, I could not find that from Glade.
+##
+## Glade seems quite awkward and clumsy.
+factory_reset_dialog_button.connect('clicked', lambda _: factory_reset_dialog.response(Gtk.ResponseType.CLOSE))
 
 try:
     subprocess.check_call([ 'sudo', '-n', 'puavo-conf-local', '--check'])

--- a/parts/laptop-setup/puavo-laptop-setup.glade
+++ b/parts/laptop-setup/puavo-laptop-setup.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkApplicationWindow" id="app_window">
@@ -26,7 +26,6 @@
         </child>
         <child>
           <object class="GtkLabel" id="puavo.abitti.version.display">
-            <property name="visible">False</property>
             <property name="can-focus">False</property>
             <property name="label" translatable="yes">eExam-system version (Abitti-compatible)</property>
           </object>
@@ -248,6 +247,100 @@
           <packing>
             <property name="left-attach">1</property>
             <property name="top-attach">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkDialog" id="factory_reset_dialog">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Factory reset</property>
+    <property name="modal">True</property>
+    <property name="type-hint">dialog</property>
+    <property name="deletable">False</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="factory_reset_dialog_button">
+                <property name="label" translatable="yes">Close</property>
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">none</property>
+            <child>
+              <object class="GtkScrolledWindow" id="factory_reset_scrolled_window">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="shadow-type">out</property>
+                <child>
+                  <object class="GtkTextView" id="factory_reset_text_view">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="editable">False</property>
+                    <property name="accepts-tab">False</property>
+                    <property name="monospace">True</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel" id="factory_reset_log_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Factory reset log</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkStatusbar" id="factory_reset_status_bar">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="margin-left">10</property>
+            <property name="margin-right">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">6</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">2</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
           </packing>
         </child>
       </object>

--- a/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
+++ b/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
@@ -7,11 +7,11 @@ request_confirmation=true
 use_secure_delete=false
 
 logmsg() {
+  printf "> %s: %s\n" "$1" "$2" >&2 || true
   logger -t puavo-reset-laptop-to-factory-defaults -p "user.${1}" "$2" || true
 }
 
 logerr() {
-  printf "> %s\n" "$1" >&2
   logmsg error "$1"
 }
 

--- a/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
+++ b/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
@@ -5,6 +5,14 @@ set -o pipefail
 
 request_confirmation=true
 use_secure_delete=false
+step=0
+
+# This basically assumes logstep is called only from the top-level,
+# which is quite reasonable assumption in this script. But note that
+# this is a hack and is not universal. It can get broken if called
+# inside a loop or from a function. But for our purposes, I think it's
+# quite nice way to report progress.
+max_steps=$(grep -c -x logstep "$0")
 
 logmsg() {
   printf "> %s: %s\n" "$1" "$2" >&2 || true
@@ -13,6 +21,11 @@ logmsg() {
 
 logerr() {
   logmsg error "$1"
+}
+
+logstep() {
+    step=$((step + 1)) || true
+    logmsg info "step ${step}/${max_steps}" || true
 }
 
 destroy_in_dir() {
@@ -199,6 +212,7 @@ done
 resetstatus=0
 
 logmsg notice "starting reset operation (${operation})"
+logstep
 
 if [ -b /dev/mapper/puavo-imageoverlays ]; then
   if ! mountpoint -q /imageoverlays; then
@@ -220,6 +234,7 @@ else
   logerr 'could not write /state/etc/puavo/primary_user_override'
   resetstatus=1
 fi
+logstep
 
 # we can speed up secure delete by not applying it to puavo-pkgs
 if destroy_in_dir --force-insecure /images/puavo-pkg/ \
@@ -229,6 +244,7 @@ else
   logerr 'error in removing all puavo-pkgs'
   resetstatus=1
 fi
+logstep
 
 if destroy_in_dir /home/ 'Cleaning up home directories'; then
   logmsg notice 'cleaned up all home directories'
@@ -236,6 +252,7 @@ else
   logerr 'error in cleaning up home directories'
   resetstatus=1
 fi
+logstep
 
 if destroy_in_dir /state/etc/puavo/local/ \
                     'Removing local configurations (made by user)'; then
@@ -244,6 +261,7 @@ else
   logerr 'error in removing local configurations'
   resetstatus=1
 fi
+logstep
 
 if destroy_in_dir /state/var/cache/ 'Cleaning up caches'; then
   logmsg info 'cleaned up caches'
@@ -251,6 +269,7 @@ else
   logerr 'error in cleaning up caches'
   resetstatus=1
 fi
+logstep
 
 if destroy_in_dir /state/var/lib/ 'Removing some system configurations'; then
   logmsg info 'removed some system configurations'
@@ -258,6 +277,7 @@ else
   logerr 'error in removing some system configurations'
   resetstatus=1
 fi
+logstep
 
 { /usr/lib/puavo-ltsp-install/update-configuration || true; } 2>&1 \
   | pv -F '>>> Updating system configuration... %t' > /dev/null
@@ -270,6 +290,7 @@ else
   logerr 'error in cleaning up (most of) /imageoverlays'
   resetstatus=1
 fi
+logstep
 
 if destroy_in_dir /state/etc/NetworkManager/system-connections/ \
                'Removing network manager connections'; then
@@ -278,6 +299,7 @@ else
   logerr 'error in removing network manager configurations'
   resetstatus=1
 fi
+logstep
 
 reset_override_path='/state/etc/puavo/reset_override'
 if [ "$resetstatus" -eq 0 ]; then
@@ -306,6 +328,7 @@ if [ "$resetstatus" -eq 0 ]; then
 else
   logmsg warning 'not sending reset state to puavo because of failures'
 fi
+logstep
 
 if destroy_in_dir --force-insecure /imageoverlays/ \
                'Cleaning up all of /imageoverlays'; then
@@ -314,6 +337,7 @@ else
   logmsg warning 'error in cleaning up all of /imageoverlays'
   resetstatus=1
 fi
+logstep
 
 if [ "$resetstatus" -ne 0 ]; then
   logerr 'errors occurred in device reset'


### PR DESCRIPTION
## Goal
Make factory reset progress visible/observable to the user.

## Changes in nutshell:
- `puavo-reset-laptop-to-factory-defaults`
  - print all messages to also stderr (previously only error message were printed)
  - log progress in steps (just "nice to have" feature to give user some idea of the overall progress)
- `puavo-laptop-setup`
  - Factory reset dialog
    - launched after the user has confirmed the factory reset
    - is modal and closing is disabled during factory reset
    - displays the live log of `puavo-reset-laptop-to-factory-defaults` in a text view

## Notes
This PR provides base for end-user triggerable "windows factory reset" -feature. Windows factory reset will inevitably take some wall clock time too and having a way to communicate the progress to the user will hopefully reduce the amount of support requests.

## TODO
- [x] German translations
- [x] Swedish translations