### PR TITLE
factory reset: apply delete_file_cmd to all files in the target dir

### DIFF
--- a/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
+++ b/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
@@ -56,10 +56,10 @@ destroy_in_dir() {
 
   {
     if $preserve_etc_puavo; then
-      find "$directory" -mindepth 5 -maxdepth 5 ! -path '*/etc/puavo' \
+      find "$directory" -mindepth 5 ! -path '*/etc/puavo' \
         -type f -print0 || return 1
     else
-      find "$directory" -mindepth 1 -maxdepth 1 -type f -print0 || return 1
+      find "$directory" -mindepth 1 -type f -print0 || return 1
     fi | { xargs -0 --no-run-if-empty $delete_file_cmd || return 1; }
 
     if $preserve_etc_puavo; then


### PR DESCRIPTION
Previously, `delete_file_cmd` was applied only to top-level files. This commit fixes the deletion by applying the deletion command to **all** files, including files in subdirs.