### PR TITLE
Factory reset: try to minimize the race condition with user session processes

### DIFF
--- a/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
+++ b/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
@@ -224,6 +224,15 @@ if [ -b /dev/mapper/puavo-imageoverlays ]; then
   fi
 fi
 
+## Best-effort killing of some possibly interfering processes
+systemctl mask colord.service || true
+systemctl stop colord.service || true
+pkill -f /usr/libexec/tracker || true
+pkill -f /usr/libexec/gvfs || true
+pkill -f /usr/bin/pulseaudio || true
+pkill -f /usr/libexec/evolution || true
+pkill -f /usr/libexec/gsd-color || true
+
 cd /
 
 # Remove primary user (so that we will send this information

--- a/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
+++ b/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
@@ -56,18 +56,18 @@ destroy_in_dir() {
 
   {
     if $preserve_etc_puavo; then
-      find "$directory" -mindepth 5 ! -path '*/etc/puavo' \
+      find "$directory" -xdev -mindepth 5 ! -path '*/etc/puavo' \
         -type f -print0 || return 1
     else
-      find "$directory" -mindepth 1 -type f -print0 || return 1
+      find "$directory" -xdev -mindepth 1 -type f -print0 || return 1
     fi | { xargs -0 --no-run-if-empty $delete_file_cmd || return 1; }
 
     if $preserve_etc_puavo; then
-      find "$directory" -mindepth 5 -maxdepth 5 ! -path '*/etc/puavo' \
+      find "$directory" -xdev -mindepth 5 -maxdepth 5 ! -path '*/etc/puavo' \
         -print0 || return 1
     else
-      find "$directory" -mindepth 1 -maxdepth 1 -print0 || return 1
-    fi | { xargs -0 --no-run-if-empty rm -rf || return 1; }
+      find "$directory" -xdev -mindepth 1 -maxdepth 1 -print0 || return 1
+    fi | { xargs -0 --no-run-if-empty rm --one-file-system -rf || return 1; }
   } | pv -F ">>> $message %t" > /dev/null
 }
 


### PR DESCRIPTION
Brings in two fixes:
- tries to deal with the inherent race condition with user session processes (some are constantly writing to home dir which can cause home dir deletion to fail)
- ensures files are deleted only from the filesystem of target dirs (submounts are ignored)