### PR TITLE
Add support for non-versioned local defaults.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .bundle/
 __pycache__/
 *.swp
+/local_defaults.mk

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ upload_pkgregex         :=
 upload_server           :=
 
 include defaults.mk
+-include local_defaults.mk
 
 ifeq "$(remote_mirror)" ""
   ifeq "$(mode)" "development"


### PR DESCRIPTION
Makefile: `-include local_defaults.mk` on top of the cake

This allows users to make their own build env customization without
constantly stashing things. I personally, have customized `image_dir`
and `rootfs_dir_base`. I know which dir paths suit my needs best.
