### PR TITLE
Puavo conf: add puavo.libcamerify.enabled

### DIFF
--- a/parts/core/puavo-conf/definitions/puavo-libcamerify.json
+++ b/parts/core/puavo-conf/definitions/puavo-libcamerify.json
@@ -1,0 +1,7 @@
+{
+  "puavo.libcamerify.enabled": {
+    "default": "false",
+    "description": "Enable/disable libcamerify, which is used to add complex camera support for some apps.",
+    "typehint": "bool"
+  }
+}

--- a/parts/core/puavo-conf/definitions/puavo-libcamerify.json
+++ b/parts/core/puavo-conf/definitions/puavo-libcamerify.json
@@ -1,7 +1,7 @@
 {
   "puavo.libcamerify.enabled": {
     "default": "false",
-    "description": "Enable/disable libcamerify, which is used to add complex camera support for some apps.",
+    "description": "Enable/disable libcamerify, which is used to add complex camera support for some apps",
     "typehint": "bool"
   }
 }


### PR DESCRIPTION
Add `puavo.libcamerify.enabled` which controls whether apps are "libcamerified" or not.

The actual "libcamerification" takes place where the app requiring it is launched. "Libcamerification" of Firefox is implemented in https://github.com/puavo-org/puavo-os-pkg/pull/1.