### PR TITLE
puavo-reset-laptop-to-factory-defaults: add --os-targets flag

### DIFF
--- a/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
+++ b/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
@@ -7,6 +7,9 @@ device_supports_discard=false
 request_confirmation=true
 use_secure_delete=true
 step=0
+do_reset_puavo_os=false
+do_reset_windows=false
+os_targets='PuavoOS'
 
 # This basically assumes logstep is called only from the top-level,
 # which is quite reasonable assumption in this script. But note that
@@ -74,10 +77,12 @@ destroy_in_dir() {
 
 usage() {
   cat <<EOF
-$(basename $0) [--force] [--insecure]
+$(basename $0) [--force] [--insecure] [--os-targets=OS_TARGETS}
 
-  --force          no questions asked
-  --insecure       be as fast as possible at the expense of security
+  --force                  no questions asked
+  --insecure               be as fast as possible at the expense of security
+  --os-targets=OS_TARGETS  comma-separated list of operating systems to reset,
+                           defaults to '${os_targets}', available choices {PuavoOS, Windows}
 EOF
   exit 1
 }
@@ -150,7 +155,7 @@ if [ "$puavo_hosttype" != "laptop" ]; then
   exit 1
 fi
 
-if ! args=$(getopt -n "$0" -o + -l 'force,insecure' -- "$@"); then
+if ! args=$(getopt -n "$0" -o + -l 'force,insecure,os-targets:' -- "$@"); then
   usage
 fi
 
@@ -159,12 +164,60 @@ while [ $# -ne 0 ]; do
   case "$1" in
     --force)    request_confirmation=false; shift ;;
     --insecure) use_secure_delete=false;    shift ;;
+    --os-targets)
+      shift
+      IFS=',' read -ra os_targets <<<"$1"
+      shift
+      ;;
     --) shift; break ;;
     *)  usage ;;
   esac
 done
 
+for os_target in "${os_targets[@]}"; do
+  case "${os_target}" in
+    PuavoOS)
+      do_reset_puavo_os=true
+      ;;
+    Windows)
+      do_reset_windows=true
+      ;;
+    *)
+      logerr "invalid operating system target '${os_target}'"
+      usage
+      ;;
+  esac
+done
+
 [ $# -eq 0 ] || usage
+
+logstep
+if $do_reset_windows; then
+  prwflags=()
+  if ! $request_confirmation; then
+    prwflags+=('--force')
+  fi
+  if $use_secure_delete; then
+    prwflags+=('--secure-delete')
+  fi
+  logmsg notice 'starting Windows reset'
+  puavo-reset-windows "${prwflags[@]}"
+else
+  logmsg notice 'skipped Windows reset'
+fi
+
+if ! $do_reset_puavo_os; then
+  logmsg notice 'skipped Puavo OS reset'
+  # Because Puavo OS reset is skipped, log all remaining steps before
+  # exiting to keep the outputted step count of this script always
+  # constant, no matter what operating systems are reset.
+  for skipped_step in $(seq "$((step + 1))" "${max_steps}"); do
+    logstep
+  done
+  exit 0
+fi
+
+# Puavo OS reset operation starts from here.
 
 if $use_secure_delete; then
   operation='reset'
@@ -212,7 +265,7 @@ done
 
 resetstatus=0
 
-logmsg notice "starting reset operation (${operation})"
+logmsg notice "starting Puavo OS reset operation (${operation})"
 logstep
 
 if [ -b /dev/mapper/puavo-imageoverlays ]; then

--- a/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
+++ b/parts/ltsp/puavo-install/puavo-reset-laptop-to-factory-defaults
@@ -180,6 +180,10 @@ for os_target in "${os_targets[@]}"; do
       do_reset_puavo_os=true
       ;;
     Windows)
+      if [ ! -e '/images/boot/.puavo_windows_partition' ]; then
+        logerr 'Windows is not installed'
+        exit 1
+      fi
       do_reset_windows=true
       ;;
     *)


### PR DESCRIPTION
To reset just Windows, run:
  `puavo-reset-laptop-to-factory-defaults --os-targets=Windows`

To reset just Puavo OS, run:
  `puavo-reset-laptop-to-factory-defaults --os-targets=PuavoOS`
or:
  `puavo-reset-laptop-to-factory-defaults`

To reset both, run:
  `puavo-reset-laptop-to-factory-defaults --os-targets=PuavoOS,Windows`