### PR TITLE
laptop-setup: add factory reset target chooser dialog

### DIFF
--- a/parts/laptop-setup/po/de/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/de/puavo-laptop-setup.po
@@ -61,15 +61,15 @@ msgstr ""
 "Weitere Informationen können aus der Werkseinstellungslog gelesen werden. "
 "Bitte Kontakt mit Helpdesk aufnehmen."
 
-#: puavo-laptop-setup:576 puavo-laptop-setup:622
+#: puavo-laptop-setup:577 puavo-laptop-setup:623
 msgid "Laptop setup"
 msgstr "Laptop Einstellungen"
 
-#: puavo-laptop-setup:612
+#: puavo-laptop-setup:613
 msgid "You do not have the required permissions to use this tool."
 msgstr "Sie haben nicht ausreichende Rechte um dieses Werkzeug zu verwenden"
 
-#: puavo-laptop-setup:622
+#: puavo-laptop-setup:623
 msgid "is already running"
 msgstr "schon im Gang"
 
@@ -116,23 +116,23 @@ msgstr "Windows aktivieren"
 
 #: puavo-laptop-setup.glade:231
 msgid "Factory reset..."
-msgstr ""
+msgstr "Das Zurücksetzen der Werkseinstellungen..."
 
 #: puavo-laptop-setup.glade:257
-msgid "Factory reset confirmation"
-msgstr ""
+msgid "Confirmation of factory reset"
+msgstr "Bestätigung des Zurücksetzens auf die Werkseinstellungen"
 
 #: puavo-laptop-setup.glade:275
 msgid "Cancel"
-msgstr ""
+msgstr "Absagen"
 
 #: puavo-laptop-setup.glade:291
 msgid "Reset"
-msgstr ""
+msgstr "Zurücksetzen"
 
 #: puavo-laptop-setup.glade:314
 msgid "Select operating systems to reset:"
-msgstr ""
+msgstr "Wählen Sie die Betriebssysteme zum Zurücksetzen aus:"
 
 #: puavo-laptop-setup.glade:324
 msgid "Puavo OS"
@@ -140,20 +140,24 @@ msgstr ""
 
 #: puavo-laptop-setup.glade:360
 msgid ""
-"<big>Factory reset will <span foreground=\"red\" size=\"x-large\">erase all "
-"user data</span> from selected operating systems and restore their state to "
+"<big>Factory reset <span foreground=\"red\" size=\"x-large\">erases all user "
+"data</span> from selected operating systems and restores their state to "
 "factory settings!</big>"
 msgstr ""
+"<big>Beim Zurücksetzen auf die Werkseinstellungen <span foreground=\"red\" "
+"size=\"x-large\"> werden alle Benutzerdaten</span> von ausgewählten "
+"Betriebssystemen <span foreground=\"red\" size=\"x-large\">gelöscht</span> "
+"und \nderen Zustand auf die Werkseinstellungen zurückgesetzt!</big>"
 
-#: puavo-laptop-setup.glade:374
+#: puavo-laptop-setup.glade:375
 msgid "Factory reset"
 msgstr "Das Zurücksetzen der Werkseinstellungen"
 
-#: puavo-laptop-setup.glade:389
+#: puavo-laptop-setup.glade:390
 msgid "Close"
 msgstr "Schließen"
 
-#: puavo-laptop-setup.glade:434
+#: puavo-laptop-setup.glade:435
 msgid "Factory reset log"
 msgstr "Protokoll zum Zurücksetzen der Werkseinstellungen"
 

--- a/parts/laptop-setup/po/de/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/de/puavo-laptop-setup.po
@@ -42,18 +42,19 @@ msgstr "Das Zurücksetzen der Werkseinstellungen wird durchgeführt"
 msgid "Failed to start factory reset"
 msgstr "Das Zurücksetzen der Werkseinstellungen konnte nicht gestartet werden"
 
-#: puavo-laptop-setup:462 puavo-laptop-setup:490
+#: puavo-laptop-setup:462 puavo-laptop-setup:493
 msgid "Factory reset failed"
 msgstr "Das Zurücksetzen der Werkseinstellungen ist gescheitert"
 
 #: puavo-laptop-setup:480
-msgid ""
-"Factory reset succeeded. The system is going to reboot in few seconds..."
-msgstr ""
-"Das Zurücksetzen der Werkseinstellungen ist gefolgt. Das System wird in "
-"einigen Sekunden neugestartet."
+msgid "Factory reset succeeded."
+msgstr "Das Zurücksetzen der Werkseinstellungen ist gefolgt."
 
-#: puavo-laptop-setup:492
+#: puavo-laptop-setup:482
+msgid "The system is going to reboot in few seconds..."
+msgstr "Das System wird in einigen Sekunden neugestartet."
+
+#: puavo-laptop-setup:495
 msgid ""
 "Further details can be found from the factory reset log. Please contact "
 "support for assistance."
@@ -61,15 +62,15 @@ msgstr ""
 "Weitere Informationen können aus der Werkseinstellungslog gelesen werden. "
 "Bitte Kontakt mit Helpdesk aufnehmen."
 
-#: puavo-laptop-setup:577 puavo-laptop-setup:623
+#: puavo-laptop-setup:580 puavo-laptop-setup:626
 msgid "Laptop setup"
 msgstr "Laptop Einstellungen"
 
-#: puavo-laptop-setup:613
+#: puavo-laptop-setup:616
 msgid "You do not have the required permissions to use this tool."
 msgstr "Sie haben nicht ausreichende Rechte um dieses Werkzeug zu verwenden"
 
-#: puavo-laptop-setup:623
+#: puavo-laptop-setup:626
 msgid "is already running"
 msgstr "schon im Gang"
 

--- a/parts/laptop-setup/po/de/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/de/puavo-laptop-setup.po
@@ -9,7 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: puavo-laptop-setup:259
+#: puavo-laptop-setup:261
 msgid ""
 "It is now possible to choose Windows from the boot menu when starting up the "
 "computer."
@@ -17,7 +17,7 @@ msgstr ""
 "Es ist jetzt möglich Windows beim Startmenü wählen. Das Menü wird kurz nach "
 "dem Einschalten von dem Computer gezeigt."
 
-#: puavo-laptop-setup:263
+#: puavo-laptop-setup:265
 msgid ""
 "Abitti-compatible eExam-system is not updated when running Windows, you have "
 "to boot into the current system to update it."
@@ -26,62 +26,50 @@ msgstr ""
 "bei Windows-Betriebssystem. Sie müssen zu diesem laufenden Betriebssystem "
 "booten um auch das Testsystem zu aktualisieren."
 
-#: puavo-laptop-setup:405
+#: puavo-laptop-setup:403
 msgid "error saving changes"
 msgstr "Fehler beim Speichern der Veränderungen"
 
-#: puavo-laptop-setup:428
-msgid "DANGER! DANGER!"
-msgstr "GEFAHR! GEFAHR!"
-
-#: puavo-laptop-setup:430
-msgid ""
-"THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!  IT WILL DESTROY "
-"ALL YOUR DATA IN YOUR HOME DIRECTORY, AND MORE!  WHEN IN DOUBT, TURN OFF THE "
-"MACHINE, PANIC AND RUN AWAY!  (press OK and provide your password if you "
-"still want to do this.)"
-msgstr ""
-" DIESE PROZEDUR WIRD DIESEN COMPUTER ZU WERKSEINSTELLUNGEN ZURÛCKSETZEN!  ES "
-"WIRD ALLE DATEN IN IHREM BENUTZERVERZEICHNIS LÖSCHEN UND MEHR! WENN SIE "
-"ZÖGERN - BITTE DEN COMPUTER ZU MACHEN UND WEG RENNEN! (Bitte OK drücken und "
-"Passwort eingeben, wenn Sie jedoch das machen wollen)"
-
-#: puavo-laptop-setup:453
+#: puavo-laptop-setup:438
 msgid "Factory reset is running step"
 msgstr "Das Zurücksetzen der Werkseinstellungen Schritt"
 
-#: puavo-laptop-setup:466
+#: puavo-laptop-setup:451
 msgid "Factory reset is running"
 msgstr "Das Zurücksetzen der Werkseinstellungen wird durchgeführt"
 
-#: puavo-laptop-setup:474
+#: puavo-laptop-setup:459
 msgid "Failed to start factory reset"
 msgstr "Das Zurücksetzen der Werkseinstellungen konnte nicht gestartet werden"
 
-#: puavo-laptop-setup:477 puavo-laptop-setup:505
+#: puavo-laptop-setup:462 puavo-laptop-setup:490
 msgid "Factory reset failed"
 msgstr "Das Zurücksetzen der Werkseinstellungen ist gescheitert"
 
-#: puavo-laptop-setup:495
+#: puavo-laptop-setup:480
 msgid ""
 "Factory reset succeeded. The system is going to reboot in few seconds..."
-msgstr "Das Zurücksetzen der Werkseinstellungen ist gefolgt. Das System wird in einigen Sekunden neugestartet."
+msgstr ""
+"Das Zurücksetzen der Werkseinstellungen ist gefolgt. Das System wird in "
+"einigen Sekunden neugestartet."
 
-#: puavo-laptop-setup:507
+#: puavo-laptop-setup:492
 msgid ""
 "Further details can be found from the factory reset log. Please contact "
 "support for assistance."
-msgstr "Weitere Informationen können aus der Werkseinstellungslog gelesen werden. Bitte Kontakt mit Helpdesk aufnehmen."
+msgstr ""
+"Weitere Informationen können aus der Werkseinstellungslog gelesen werden. "
+"Bitte Kontakt mit Helpdesk aufnehmen."
 
-#: puavo-laptop-setup:572 puavo-laptop-setup:602
+#: puavo-laptop-setup:576 puavo-laptop-setup:622
 msgid "Laptop setup"
 msgstr "Laptop Einstellungen"
 
-#: puavo-laptop-setup:592
+#: puavo-laptop-setup:612
 msgid "You do not have the required permissions to use this tool."
 msgstr "Sie haben nicht ausreichende Rechte um dieses Werkzeug zu verwenden"
 
-#: puavo-laptop-setup:602
+#: puavo-laptop-setup:622
 msgid "is already running"
 msgstr "schon im Gang"
 
@@ -117,7 +105,7 @@ msgstr "Puavo OS (Linux)"
 msgid "eExam-system"
 msgstr "Elektronisches Test-System (Abitti)"
 
-#: puavo-laptop-setup.glade:176
+#: puavo-laptop-setup.glade:176 puavo-laptop-setup.glade:340
 msgid "Windows"
 msgstr "Windows"
 
@@ -127,23 +115,68 @@ msgid "Start using Windows"
 msgstr "Windows aktivieren"
 
 #: puavo-laptop-setup.glade:231
-msgid ""
-"Destroy all user data and reset laptop to factory state (requires password)"
+msgid "Factory reset..."
 msgstr ""
-"Alle Benutzerdaten löschen und das System zu Werkseinstellungen "
-"zurücksetzen. (Passwort erforderlich)"
 
 #: puavo-laptop-setup.glade:257
+msgid "Factory reset confirmation"
+msgstr ""
+
+#: puavo-laptop-setup.glade:275
+msgid "Cancel"
+msgstr ""
+
+#: puavo-laptop-setup.glade:291
+msgid "Reset"
+msgstr ""
+
+#: puavo-laptop-setup.glade:314
+msgid "Select operating systems to reset:"
+msgstr ""
+
+#: puavo-laptop-setup.glade:324
+msgid "Puavo OS"
+msgstr ""
+
+#: puavo-laptop-setup.glade:360
+msgid ""
+"<big>Factory reset will <span foreground=\"red\" size=\"x-large\">erase all "
+"user data</span> from selected operating systems and restore their state to "
+"factory settings!</big>"
+msgstr ""
+
+#: puavo-laptop-setup.glade:374
 msgid "Factory reset"
 msgstr "Das Zurücksetzen der Werkseinstellungen"
 
-#: puavo-laptop-setup.glade:272
+#: puavo-laptop-setup.glade:389
 msgid "Close"
 msgstr "Schließen"
 
-#: puavo-laptop-setup.glade:317
+#: puavo-laptop-setup.glade:434
 msgid "Factory reset log"
 msgstr "Protokoll zum Zurücksetzen der Werkseinstellungen"
+
+#~ msgid "DANGER! DANGER!"
+#~ msgstr "GEFAHR! GEFAHR!"
+
+#~ msgid ""
+#~ "THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!  IT WILL "
+#~ "DESTROY ALL YOUR DATA IN YOUR HOME DIRECTORY, AND MORE!  WHEN IN DOUBT, "
+#~ "TURN OFF THE MACHINE, PANIC AND RUN AWAY!  (press OK and provide your "
+#~ "password if you still want to do this.)"
+#~ msgstr ""
+#~ " DIESE PROZEDUR WIRD DIESEN COMPUTER ZU WERKSEINSTELLUNGEN ZURÛCKSETZEN!  "
+#~ "ES WIRD ALLE DATEN IN IHREM BENUTZERVERZEICHNIS LÖSCHEN UND MEHR! WENN "
+#~ "SIE ZÖGERN - BITTE DEN COMPUTER ZU MACHEN UND WEG RENNEN! (Bitte OK "
+#~ "drücken und Passwort eingeben, wenn Sie jedoch das machen wollen)"
+
+#~ msgid ""
+#~ "Destroy all user data and reset laptop to factory state (requires "
+#~ "password)"
+#~ msgstr ""
+#~ "Alle Benutzerdaten löschen und das System zu Werkseinstellungen "
+#~ "zurücksetzen. (Passwort erforderlich)"
 
 #~ msgid "latest"
 #~ msgstr "letzte"

--- a/parts/laptop-setup/po/fi/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/fi/puavo-laptop-setup.po
@@ -9,7 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: puavo-laptop-setup:259
+#: puavo-laptop-setup:261
 msgid ""
 "It is now possible to choose Windows from the boot menu when starting up the "
 "computer."
@@ -18,7 +18,7 @@ msgstr ""
 "käynnistysvalikkoon. Käynnistysvalikko tulee näkyviin aina tietokoneen "
 "uudelleen käynnistyksen yhteydessä."
 
-#: puavo-laptop-setup:263
+#: puavo-laptop-setup:265
 msgid ""
 "Abitti-compatible eExam-system is not updated when running Windows, you have "
 "to boot into the current system to update it."
@@ -29,50 +29,34 @@ msgstr ""
 "käynnistyksen yhteydessä 'Normaali käynnistys' ja käynnistää tähän nyt "
 "käytössä olevaan Opinsys OS -käyttöjärjestelmään."
 
-#: puavo-laptop-setup:405
+#: puavo-laptop-setup:403
 msgid "error saving changes"
 msgstr "virhe tallennuksessa"
 
-#: puavo-laptop-setup:428
-msgid "DANGER! DANGER!"
-msgstr "VAARA! VAARA!"
-
-#: puavo-laptop-setup:430
-msgid ""
-"THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!  IT WILL DESTROY "
-"ALL YOUR DATA IN YOUR HOME DIRECTORY, AND MORE!  WHEN IN DOUBT, TURN OFF THE "
-"MACHINE, PANIC AND RUN AWAY!  (press OK and provide your password if you "
-"still want to do this.)"
-msgstr ""
-"TÄMÄ TOIMENPIDE PALAUTTAA TÄMÄN TIETOKONEEN TEHDASASETUKSILLE! SE TUHOAA "
-"KAIKEN DATAN KOTIHAKEMISTOSSASI, JA ENEMMÄNKIN! JOS EPÄILET OLLENKAAN, "
-"SAMMUTA KONE, PANIKOI JA JUOKSE KARKUUN! (paina OK ja anna salasanasi jos "
-"haluat kuitenkin tehdä tämän.)"
-
-#: puavo-laptop-setup:453
+#: puavo-laptop-setup:438
 msgid "Factory reset is running step"
 msgstr "Tehdasasetusten palautus on käynnissä vaiheessa"
 
-#: puavo-laptop-setup:466
+#: puavo-laptop-setup:451
 msgid "Factory reset is running"
 msgstr "Tehdasasetusten palautus on käynnissä"
 
-#: puavo-laptop-setup:474
+#: puavo-laptop-setup:459
 msgid "Failed to start factory reset"
 msgstr "Tehdasasetusten palautuksen käynnistys epäonnistui"
 
-#: puavo-laptop-setup:477 puavo-laptop-setup:505
+#: puavo-laptop-setup:462 puavo-laptop-setup:490
 msgid "Factory reset failed"
 msgstr "Tehdasasetusten palautus epäonnistui"
 
-#: puavo-laptop-setup:495
+#: puavo-laptop-setup:480
 msgid ""
 "Factory reset succeeded. The system is going to reboot in few seconds..."
 msgstr ""
 "Tehdasasetusten palautus onnistui. Järjestelmä käynnistyy uudestaan muutaman "
 "sekunnin kuluessa..."
 
-#: puavo-laptop-setup:507
+#: puavo-laptop-setup:492
 msgid ""
 "Further details can be found from the factory reset log. Please contact "
 "support for assistance."
@@ -80,15 +64,15 @@ msgstr ""
 "Tarkemmat tiedot virheestä löytyvät tehdasasetusten palautuslokista. Olkaa "
 "hyvä ja ottakaa yhteyttä tukeen ongelman selvittämiseksi."
 
-#: puavo-laptop-setup:572 puavo-laptop-setup:602
+#: puavo-laptop-setup:576 puavo-laptop-setup:622
 msgid "Laptop setup"
 msgstr "Kannettavan asetukset"
 
-#: puavo-laptop-setup:592
+#: puavo-laptop-setup:612
 msgid "You do not have the required permissions to use this tool."
 msgstr "Sinulla ei ole tarvittavia oikeuksia tämän työkalun käyttöön."
 
-#: puavo-laptop-setup:602
+#: puavo-laptop-setup:622
 msgid "is already running"
 msgstr "on jo käynnissä"
 
@@ -124,7 +108,7 @@ msgstr ""
 msgid "eExam-system"
 msgstr "Koejärjestelmä"
 
-#: puavo-laptop-setup.glade:176
+#: puavo-laptop-setup.glade:176 puavo-laptop-setup.glade:340
 msgid "Windows"
 msgstr ""
 
@@ -134,22 +118,67 @@ msgid "Start using Windows"
 msgstr "Ota Windows käyttöön"
 
 #: puavo-laptop-setup.glade:231
-msgid ""
-"Destroy all user data and reset laptop to factory state (requires password)"
+msgid "Factory reset..."
 msgstr ""
-"Tuhoa kaikki tiedot ja palauta tietokone tehdastilaan (vaatii salasanan)"
 
 #: puavo-laptop-setup.glade:257
+msgid "Factory reset confirmation"
+msgstr ""
+
+#: puavo-laptop-setup.glade:275
+msgid "Cancel"
+msgstr ""
+
+#: puavo-laptop-setup.glade:291
+msgid "Reset"
+msgstr ""
+
+#: puavo-laptop-setup.glade:314
+msgid "Select operating systems to reset:"
+msgstr ""
+
+#: puavo-laptop-setup.glade:324
+msgid "Puavo OS"
+msgstr ""
+
+#: puavo-laptop-setup.glade:360
+msgid ""
+"<big>Factory reset will <span foreground=\"red\" size=\"x-large\">erase all "
+"user data</span> from selected operating systems and restore their state to "
+"factory settings!</big>"
+msgstr ""
+
+#: puavo-laptop-setup.glade:374
 msgid "Factory reset"
 msgstr "Tehdasasetusten palautus"
 
-#: puavo-laptop-setup.glade:272
+#: puavo-laptop-setup.glade:389
 msgid "Close"
 msgstr "Sulje"
 
-#: puavo-laptop-setup.glade:317
+#: puavo-laptop-setup.glade:434
 msgid "Factory reset log"
 msgstr "Tehdaasetusten palautusloki"
+
+#~ msgid "DANGER! DANGER!"
+#~ msgstr "VAARA! VAARA!"
+
+#~ msgid ""
+#~ "THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!  IT WILL "
+#~ "DESTROY ALL YOUR DATA IN YOUR HOME DIRECTORY, AND MORE!  WHEN IN DOUBT, "
+#~ "TURN OFF THE MACHINE, PANIC AND RUN AWAY!  (press OK and provide your "
+#~ "password if you still want to do this.)"
+#~ msgstr ""
+#~ "TÄMÄ TOIMENPIDE PALAUTTAA TÄMÄN TIETOKONEEN TEHDASASETUKSILLE! SE TUHOAA "
+#~ "KAIKEN DATAN KOTIHAKEMISTOSSASI, JA ENEMMÄNKIN! JOS EPÄILET OLLENKAAN, "
+#~ "SAMMUTA KONE, PANIKOI JA JUOKSE KARKUUN! (paina OK ja anna salasanasi jos "
+#~ "haluat kuitenkin tehdä tämän.)"
+
+#~ msgid ""
+#~ "Destroy all user data and reset laptop to factory state (requires "
+#~ "password)"
+#~ msgstr ""
+#~ "Tuhoa kaikki tiedot ja palauta tietokone tehdastilaan (vaatii salasanan)"
 
 #~ msgid "latest"
 #~ msgstr "viimeisin"

--- a/parts/laptop-setup/po/fi/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/fi/puavo-laptop-setup.po
@@ -64,15 +64,15 @@ msgstr ""
 "Tarkemmat tiedot virheestä löytyvät tehdasasetusten palautuslokista. Olkaa "
 "hyvä ja ottakaa yhteyttä tukeen ongelman selvittämiseksi."
 
-#: puavo-laptop-setup:576 puavo-laptop-setup:622
+#: puavo-laptop-setup:577 puavo-laptop-setup:623
 msgid "Laptop setup"
 msgstr "Kannettavan asetukset"
 
-#: puavo-laptop-setup:612
+#: puavo-laptop-setup:613
 msgid "You do not have the required permissions to use this tool."
 msgstr "Sinulla ei ole tarvittavia oikeuksia tämän työkalun käyttöön."
 
-#: puavo-laptop-setup:622
+#: puavo-laptop-setup:623
 msgid "is already running"
 msgstr "on jo käynnissä"
 
@@ -119,23 +119,23 @@ msgstr "Ota Windows käyttöön"
 
 #: puavo-laptop-setup.glade:231
 msgid "Factory reset..."
-msgstr ""
+msgstr "Tehdasasetusten palautus..."
 
 #: puavo-laptop-setup.glade:257
-msgid "Factory reset confirmation"
-msgstr ""
+msgid "Confirmation of factory reset"
+msgstr "Vahvistus tehdasasetusten palautukselle"
 
 #: puavo-laptop-setup.glade:275
 msgid "Cancel"
-msgstr ""
+msgstr "Peruuta"
 
 #: puavo-laptop-setup.glade:291
 msgid "Reset"
-msgstr ""
+msgstr "Palauta tehdasasetuksille"
 
 #: puavo-laptop-setup.glade:314
 msgid "Select operating systems to reset:"
-msgstr ""
+msgstr "Valitse tehdasasetuksille palautettavat käyttöjärjestelmät:"
 
 #: puavo-laptop-setup.glade:324
 msgid "Puavo OS"
@@ -143,20 +143,23 @@ msgstr ""
 
 #: puavo-laptop-setup.glade:360
 msgid ""
-"<big>Factory reset will <span foreground=\"red\" size=\"x-large\">erase all "
-"user data</span> from selected operating systems and restore their state to "
+"<big>Factory reset <span foreground=\"red\" size=\"x-large\">erases all user "
+"data</span> from selected operating systems and restores their state to "
 "factory settings!</big>"
 msgstr ""
+"<big>Tehdasasetusten palautus <span foreground=\"red\" size=\"x-"
+"large\">tuhoaa kaiken datan</span> valituista käyttöjärjestelmistä ja "
+"palauttaa ne takaisin tehdasasetuksille!</big>"
 
-#: puavo-laptop-setup.glade:374
+#: puavo-laptop-setup.glade:375
 msgid "Factory reset"
 msgstr "Tehdasasetusten palautus"
 
-#: puavo-laptop-setup.glade:389
+#: puavo-laptop-setup.glade:390
 msgid "Close"
 msgstr "Sulje"
 
-#: puavo-laptop-setup.glade:434
+#: puavo-laptop-setup.glade:435
 msgid "Factory reset log"
 msgstr "Tehdaasetusten palautusloki"
 

--- a/parts/laptop-setup/po/fi/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/fi/puavo-laptop-setup.po
@@ -45,18 +45,19 @@ msgstr "Tehdasasetusten palautus on käynnissä"
 msgid "Failed to start factory reset"
 msgstr "Tehdasasetusten palautuksen käynnistys epäonnistui"
 
-#: puavo-laptop-setup:462 puavo-laptop-setup:490
+#: puavo-laptop-setup:462 puavo-laptop-setup:493
 msgid "Factory reset failed"
 msgstr "Tehdasasetusten palautus epäonnistui"
 
 #: puavo-laptop-setup:480
-msgid ""
-"Factory reset succeeded. The system is going to reboot in few seconds..."
-msgstr ""
-"Tehdasasetusten palautus onnistui. Järjestelmä käynnistyy uudestaan muutaman "
-"sekunnin kuluessa..."
+msgid "Factory reset succeeded."
+msgstr "Tehdasasetusten palautus onnistui."
 
-#: puavo-laptop-setup:492
+#: puavo-laptop-setup:482
+msgid "The system is going to reboot in few seconds..."
+msgstr "Järjestelmä käynnistyy uudestaan muutaman sekunnin kuluessa..."
+
+#: puavo-laptop-setup:495
 msgid ""
 "Further details can be found from the factory reset log. Please contact "
 "support for assistance."
@@ -64,15 +65,15 @@ msgstr ""
 "Tarkemmat tiedot virheestä löytyvät tehdasasetusten palautuslokista. Olkaa "
 "hyvä ja ottakaa yhteyttä tukeen ongelman selvittämiseksi."
 
-#: puavo-laptop-setup:577 puavo-laptop-setup:623
+#: puavo-laptop-setup:580 puavo-laptop-setup:626
 msgid "Laptop setup"
 msgstr "Kannettavan asetukset"
 
-#: puavo-laptop-setup:613
+#: puavo-laptop-setup:616
 msgid "You do not have the required permissions to use this tool."
 msgstr "Sinulla ei ole tarvittavia oikeuksia tämän työkalun käyttöön."
 
-#: puavo-laptop-setup:623
+#: puavo-laptop-setup:626
 msgid "is already running"
 msgstr "on jo käynnissä"
 

--- a/parts/laptop-setup/po/sv/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/sv/puavo-laptop-setup.po
@@ -60,15 +60,15 @@ msgstr ""
 "Ytterligare detaljer kan hittas från fabriksåterställningsloggen. Kontakta "
 "supporten för hjälp."
 
-#: puavo-laptop-setup:576 puavo-laptop-setup:622
+#: puavo-laptop-setup:577 puavo-laptop-setup:623
 msgid "Laptop setup"
 msgstr "Laptop inställningar"
 
-#: puavo-laptop-setup:612
+#: puavo-laptop-setup:613
 msgid "You do not have the required permissions to use this tool."
 msgstr "Du har inte tillräckliga rättigheter att använda verktyget."
 
-#: puavo-laptop-setup:622
+#: puavo-laptop-setup:623
 msgid "is already running"
 msgstr "är redan igång"
 
@@ -115,23 +115,23 @@ msgstr "Aktivera Windows"
 
 #: puavo-laptop-setup.glade:231
 msgid "Factory reset..."
-msgstr ""
+msgstr "Fabriksåterställning..."
 
 #: puavo-laptop-setup.glade:257
-msgid "Factory reset confirmation"
-msgstr ""
+msgid "Confirmation of factory reset"
+msgstr "Bekräftelse på fabriksåterställning"
 
 #: puavo-laptop-setup.glade:275
 msgid "Cancel"
-msgstr ""
+msgstr "Avbryt"
 
 #: puavo-laptop-setup.glade:291
 msgid "Reset"
-msgstr ""
+msgstr "Återställa"
 
 #: puavo-laptop-setup.glade:314
 msgid "Select operating systems to reset:"
-msgstr ""
+msgstr "Välj operativsystem som ska återställas:"
 
 #: puavo-laptop-setup.glade:324
 msgid "Puavo OS"
@@ -139,20 +139,23 @@ msgstr ""
 
 #: puavo-laptop-setup.glade:360
 msgid ""
-"<big>Factory reset will <span foreground=\"red\" size=\"x-large\">erase all "
-"user data</span> from selected operating systems and restore their state to "
+"<big>Factory reset <span foreground=\"red\" size=\"x-large\">erases all user "
+"data</span> from selected operating systems and restores their state to "
 "factory settings!</big>"
 msgstr ""
+"<big>Fabriksåterställning <span foreground=\"red\" size=\"x-large\"> raderar "
+"all användardata</span> från valda operativsystem och återställer deras "
+"tillstånd till fabriksinställningarna!</big>"
 
-#: puavo-laptop-setup.glade:374
+#: puavo-laptop-setup.glade:375
 msgid "Factory reset"
 msgstr "Fabriksåterställning"
 
-#: puavo-laptop-setup.glade:389
+#: puavo-laptop-setup.glade:390
 msgid "Close"
 msgstr "Stäng"
 
-#: puavo-laptop-setup.glade:434
+#: puavo-laptop-setup.glade:435
 msgid "Factory reset log"
 msgstr "Fabriksåterställningslogg"
 

--- a/parts/laptop-setup/po/sv/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/sv/puavo-laptop-setup.po
@@ -9,7 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: puavo-laptop-setup:259
+#: puavo-laptop-setup:261
 msgid ""
 "It is now possible to choose Windows from the boot menu when starting up the "
 "computer."
@@ -17,7 +17,7 @@ msgstr ""
 "Windows har nu tilläggats till startmenun. Menun syns alltid när man startar "
 "om datorn."
 
-#: puavo-laptop-setup:263
+#: puavo-laptop-setup:265
 msgid ""
 "Abitti-compatible eExam-system is not updated when running Windows, you have "
 "to boot into the current system to update it."
@@ -26,62 +26,49 @@ msgstr ""
 "till Windows. För att byta / uppdatera din laptops Abitti-system måste man "
 "välja normal start och välja det här Opinsys Os som används nu. "
 
-#: puavo-laptop-setup:405
+#: puavo-laptop-setup:403
 msgid "error saving changes"
 msgstr "fel i sparning av ändringarna "
 
-#: puavo-laptop-setup:428
-msgid "DANGER! DANGER!"
-msgstr "FARA! FARA!"
-
-#: puavo-laptop-setup:430
-msgid ""
-"THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!  IT WILL DESTROY "
-"ALL YOUR DATA IN YOUR HOME DIRECTORY, AND MORE!  WHEN IN DOUBT, TURN OFF THE "
-"MACHINE, PANIC AND RUN AWAY!  (press OK and provide your password if you "
-"still want to do this.)"
-msgstr ""
-" DENNA PROCEDUR KOMMER ATT ÅTERSTÄLLA DENNA DATOR TILL "
-"FABRIKSINSTÄLLNINGARNA.  DET KOMMER FÖRSTÖRA ALL DATA I HEMKATALOG OCH MERA! "
-"OM DU TVIVLAR - STÄNG DATOR, GÅ I PANIK OCH SPRING BORT! (Tryck OK och ge "
-"ditt lösenord om du ändå vill göra det här.)"
-
-#: puavo-laptop-setup:453
+#: puavo-laptop-setup:438
 msgid "Factory reset is running step"
 msgstr "Fabriksåterställning kör steg"
 
-#: puavo-laptop-setup:466
+#: puavo-laptop-setup:451
 msgid "Factory reset is running"
 msgstr "Fabriksåterställning pågår"
 
-#: puavo-laptop-setup:474
+#: puavo-laptop-setup:459
 msgid "Failed to start factory reset"
 msgstr "Fabriksåterställningen kunde inte börjas"
 
-#: puavo-laptop-setup:477 puavo-laptop-setup:505
+#: puavo-laptop-setup:462 puavo-laptop-setup:490
 msgid "Factory reset failed"
 msgstr "Fabriksåterställningen mislyckades"
 
-#: puavo-laptop-setup:495
+#: puavo-laptop-setup:480
 msgid ""
 "Factory reset succeeded. The system is going to reboot in few seconds..."
-msgstr "Fabriksåterställningen lyckades. Systemet startar om i några sekunder..."
+msgstr ""
+"Fabriksåterställningen lyckades. Systemet startar om i några sekunder..."
 
-#: puavo-laptop-setup:507
+#: puavo-laptop-setup:492
 msgid ""
 "Further details can be found from the factory reset log. Please contact "
 "support for assistance."
-msgstr "Ytterligare detaljer kan hittas från fabriksåterställningsloggen. Kontakta supporten för hjälp."
+msgstr ""
+"Ytterligare detaljer kan hittas från fabriksåterställningsloggen. Kontakta "
+"supporten för hjälp."
 
-#: puavo-laptop-setup:572 puavo-laptop-setup:602
+#: puavo-laptop-setup:576 puavo-laptop-setup:622
 msgid "Laptop setup"
 msgstr "Laptop inställningar"
 
-#: puavo-laptop-setup:592
+#: puavo-laptop-setup:612
 msgid "You do not have the required permissions to use this tool."
 msgstr "Du har inte tillräckliga rättigheter att använda verktyget."
 
-#: puavo-laptop-setup:602
+#: puavo-laptop-setup:622
 msgid "is already running"
 msgstr "är redan igång"
 
@@ -117,7 +104,7 @@ msgstr "Puavo OS (Linux)"
 msgid "eExam-system"
 msgstr "eProv-system Abitti"
 
-#: puavo-laptop-setup.glade:176
+#: puavo-laptop-setup.glade:176 puavo-laptop-setup.glade:340
 msgid "Windows"
 msgstr "Windows"
 
@@ -127,23 +114,68 @@ msgid "Start using Windows"
 msgstr "Aktivera Windows"
 
 #: puavo-laptop-setup.glade:231
-msgid ""
-"Destroy all user data and reset laptop to factory state (requires password)"
+msgid "Factory reset..."
 msgstr ""
-"Förstör all data och återställ datorn till fabriksinställningarna (kräver "
-"lösenord)"
 
 #: puavo-laptop-setup.glade:257
+msgid "Factory reset confirmation"
+msgstr ""
+
+#: puavo-laptop-setup.glade:275
+msgid "Cancel"
+msgstr ""
+
+#: puavo-laptop-setup.glade:291
+msgid "Reset"
+msgstr ""
+
+#: puavo-laptop-setup.glade:314
+msgid "Select operating systems to reset:"
+msgstr ""
+
+#: puavo-laptop-setup.glade:324
+msgid "Puavo OS"
+msgstr ""
+
+#: puavo-laptop-setup.glade:360
+msgid ""
+"<big>Factory reset will <span foreground=\"red\" size=\"x-large\">erase all "
+"user data</span> from selected operating systems and restore their state to "
+"factory settings!</big>"
+msgstr ""
+
+#: puavo-laptop-setup.glade:374
 msgid "Factory reset"
 msgstr "Fabriksåterställning"
 
-#: puavo-laptop-setup.glade:272
+#: puavo-laptop-setup.glade:389
 msgid "Close"
 msgstr "Stäng"
 
-#: puavo-laptop-setup.glade:317
+#: puavo-laptop-setup.glade:434
 msgid "Factory reset log"
 msgstr "Fabriksåterställningslogg"
+
+#~ msgid "DANGER! DANGER!"
+#~ msgstr "FARA! FARA!"
+
+#~ msgid ""
+#~ "THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!  IT WILL "
+#~ "DESTROY ALL YOUR DATA IN YOUR HOME DIRECTORY, AND MORE!  WHEN IN DOUBT, "
+#~ "TURN OFF THE MACHINE, PANIC AND RUN AWAY!  (press OK and provide your "
+#~ "password if you still want to do this.)"
+#~ msgstr ""
+#~ " DENNA PROCEDUR KOMMER ATT ÅTERSTÄLLA DENNA DATOR TILL "
+#~ "FABRIKSINSTÄLLNINGARNA.  DET KOMMER FÖRSTÖRA ALL DATA I HEMKATALOG OCH "
+#~ "MERA! OM DU TVIVLAR - STÄNG DATOR, GÅ I PANIK OCH SPRING BORT! (Tryck OK "
+#~ "och ge ditt lösenord om du ändå vill göra det här.)"
+
+#~ msgid ""
+#~ "Destroy all user data and reset laptop to factory state (requires "
+#~ "password)"
+#~ msgstr ""
+#~ "Förstör all data och återställ datorn till fabriksinställningarna (kräver "
+#~ "lösenord)"
 
 #~ msgid "latest"
 #~ msgstr "senast"

--- a/parts/laptop-setup/po/sv/puavo-laptop-setup.po
+++ b/parts/laptop-setup/po/sv/puavo-laptop-setup.po
@@ -42,17 +42,19 @@ msgstr "Fabriksåterställning pågår"
 msgid "Failed to start factory reset"
 msgstr "Fabriksåterställningen kunde inte börjas"
 
-#: puavo-laptop-setup:462 puavo-laptop-setup:490
+#: puavo-laptop-setup:462 puavo-laptop-setup:493
 msgid "Factory reset failed"
 msgstr "Fabriksåterställningen mislyckades"
 
 #: puavo-laptop-setup:480
-msgid ""
-"Factory reset succeeded. The system is going to reboot in few seconds..."
-msgstr ""
-"Fabriksåterställningen lyckades. Systemet startar om i några sekunder..."
+msgid "Factory reset succeeded."
+msgstr "Fabriksåterställningen lyckades."
 
-#: puavo-laptop-setup:492
+#: puavo-laptop-setup:482
+msgid "The system is going to reboot in few seconds..."
+msgstr "Systemet startar om i några sekunder..."
+
+#: puavo-laptop-setup:495
 msgid ""
 "Further details can be found from the factory reset log. Please contact "
 "support for assistance."
@@ -60,15 +62,15 @@ msgstr ""
 "Ytterligare detaljer kan hittas från fabriksåterställningsloggen. Kontakta "
 "supporten för hjälp."
 
-#: puavo-laptop-setup:577 puavo-laptop-setup:623
+#: puavo-laptop-setup:580 puavo-laptop-setup:626
 msgid "Laptop setup"
 msgstr "Laptop inställningar"
 
-#: puavo-laptop-setup:613
+#: puavo-laptop-setup:616
 msgid "You do not have the required permissions to use this tool."
 msgstr "Du har inte tillräckliga rättigheter att använda verktyget."
 
-#: puavo-laptop-setup:623
+#: puavo-laptop-setup:626
 msgid "is already running"
 msgstr "är redan igång"
 

--- a/parts/laptop-setup/puavo-laptop-setup
+++ b/parts/laptop-setup/puavo-laptop-setup
@@ -36,6 +36,8 @@ def strip_abitti_v(value):
         return value.replace('abitti-v', '')
     return value
 
+def we_have_windows():
+    return os.path.exists('/images/boot/.puavo_windows_partition')
 
 class PuavoLaptopSetup:
     def __init__(self, app_window, builder):
@@ -281,17 +283,13 @@ class PuavoLaptopSetup:
                  and type(self.abitti_info['build_numbers']) == dict
 
 
-    def we_have_windows(self):
-        return os.path.exists('/images/boot/.puavo_windows_partition')
-
-
     def remove_entries_without_puavoconf(self):
         remove_gui_elements = {}
 
         if not self.we_have_abitti():
             del self.puavo_conf['puavo.abitti.version']
 
-        if not self.we_have_windows():
+        if not we_have_windows():
             del self.puavo_conf['puavo.grub.windows.enabled']
 
         if not 'puavo.abitti.version' in self.puavo_conf:
@@ -419,24 +417,11 @@ class PuavoLaptopSetup:
 
 
     def confirm_reset_to_factory_settings(self, widget):
-        dialog = Gtk.MessageDialog(
-            parent=self.app_window,
-            modal=True,
-            destroy_with_parent=True,
-            message_type=Gtk.MessageType.WARNING,
-            buttons=Gtk.ButtonsType.OK_CANCEL,
-            text=_tr('DANGER! DANGER!'),
-            secondary_text=_tr(
-              'THIS PROCEDURE WILL RESET THIS COMPUTER TO FACTORY STATE!' \
-              + '  IT WILL DESTROY ALL YOUR DATA IN YOUR HOME DIRECTORY,' \
-              + ' AND MORE!  WHEN IN DOUBT, TURN OFF THE MACHINE, PANIC' \
-              + ' AND RUN AWAY!  (press OK and provide your password' \
-              + ' if you still want to do this.)')
-        )
-        response = dialog.run()
+        target_chooser_dialog
+        response = target_chooser_dialog.run()
+        target_chooser_dialog.hide()
         if response == Gtk.ResponseType.OK:
           self.run_reset_to_factory_settings()
-        dialog.destroy()
 
 
     def run_reset_to_factory_settings(self):
@@ -518,9 +503,18 @@ class PuavoLaptopSetup:
             return False
 
         def run_cmd():
+            os_targets = []
+            if target_checkbutton_windows.get_active():
+                os_targets.append('Windows')
+            if target_checkbutton_puavo_os.get_active():
+                os_targets.append('PuavoOS')
+
             cmd = [ 'pkexec',
                     '/usr/sbin/puavo-reset-laptop-to-factory-defaults',
-                    '--force' ]
+                    '--force',
+                    '--os-targets',
+                    ','.join(os_targets),
+                   ]
 
             cmd_process = None
             try:
@@ -548,20 +542,31 @@ class PuavoLaptopSetup:
         factory_reset_dialog.run()
         factory_reset_dialog.hide()
 
-def on_factory_reset_dialog_delete_event(dialog, event):
-    # We don't want to destroy the factory reset dialog because the
-    # user might re-enter or retry it. The dialog is created by
-    # builder only once.
 
+def on_dialog_delete_event(dialog, event):
+    # We don't want to destroy the dialog because the user might
+    # re-enter or retry it. The dialog is created by builder only
+    # once.
+    #
     # The other way would be to actually destroy them, but then
     # recreating would mean we would need to create a new builder each
     # time the dialog is shown. See
     # https://discourse.gnome.org/t/cannot-reopen-dialog-after-closed-with-x-if-using-gtkbuilder-for-construction/7019
     #
-    # I thing hiding is fine. Recreating builder and new dialog each
+    # I think hiding is fine. Recreating builder and new dialog each
     # time seems unncessary waste of resources.
     dialog.hide()
     return True
+
+def on_target_chooser_dialog_show(_):
+    target_checkbutton_windows.set_visible(we_have_windows())
+    target_checkbutton_windows.set_active(False)
+    target_checkbutton_puavo_os.set_active(False)
+
+def on_target_checkbutton_toggled(_):
+    target_chooser_dialog_button_reset.set_sensitive(
+        target_checkbutton_windows.get_active() or target_checkbutton_puavo_os.get_active()
+    )
 
 builder = Gtk.Builder()
 builder.set_translation_domain('puavo-laptop-setup')
@@ -573,7 +578,7 @@ app_window.set_title(_tr('Laptop setup'))
 app_window.connect('destroy', Gtk.main_quit)
 
 factory_reset_dialog = builder.get_object('factory_reset_dialog')
-factory_reset_dialog.connect('delete-event', on_factory_reset_dialog_delete_event)
+factory_reset_dialog.connect('delete-event', on_dialog_delete_event)
 factory_reset_dialog.set_size_request(800, 400)
 
 factory_reset_dialog_button = builder.get_object('factory_reset_dialog_button')
@@ -585,6 +590,22 @@ factory_reset_dialog_button = builder.get_object('factory_reset_dialog_button')
 ##
 ## Glade seems quite awkward and clumsy.
 factory_reset_dialog_button.connect('clicked', lambda _: factory_reset_dialog.response(Gtk.ResponseType.CLOSE))
+
+target_chooser_dialog = builder.get_object('target_chooser_dialog')
+target_chooser_dialog.connect('delete-event', on_dialog_delete_event)
+target_chooser_dialog.connect('show', on_target_chooser_dialog_show)
+
+target_chooser_dialog_button_cancel = builder.get_object('target_chooser_dialog_button_cancel')
+target_chooser_dialog_button_cancel.connect('clicked', lambda _: target_chooser_dialog.response(Gtk.ResponseType.CANCEL))
+
+target_chooser_dialog_button_reset = builder.get_object('target_chooser_dialog_button_reset')
+target_chooser_dialog_button_reset.connect('clicked', lambda _: target_chooser_dialog.response(Gtk.ResponseType.OK))
+
+target_checkbutton_windows = builder.get_object('target_checkbutton_windows')
+target_checkbutton_windows.connect('toggled', on_target_checkbutton_toggled)
+target_checkbutton_puavo_os = builder.get_object('target_checkbutton_puavo_os')
+target_checkbutton_puavo_os.connect('toggled', on_target_checkbutton_toggled)
+
 
 try:
     subprocess.check_call([ 'sudo', '-n', 'puavo-conf-local', '--check'])

--- a/parts/laptop-setup/puavo-laptop-setup
+++ b/parts/laptop-setup/puavo-laptop-setup
@@ -477,7 +477,10 @@ class PuavoLaptopSetup:
             factory_reset_dialog.set_deletable(True)
             factory_reset_dialog_button.set_sensitive(True)
             if returnvalue == 0:
-                text = _tr('Factory reset succeeded. The system is going to reboot in few seconds...')
+                texts = [_tr('Factory reset succeeded.')]
+                if target_checkbutton_puavo_os.get_active():
+                    texts.append(_tr('The system is going to reboot in few seconds...'))
+                text = ' '.join(texts)
                 factory_reset_status_bar.push(context_id, text)
                 dialog = Gtk.MessageDialog(
                     parent=factory_reset_dialog,

--- a/parts/laptop-setup/puavo-laptop-setup.glade
+++ b/parts/laptop-setup/puavo-laptop-setup.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk+" version="3.24"/>
   <object class="GtkApplicationWindow" id="app_window">
     <property name="can-focus">False</property>
     <property name="border-width">20</property>
@@ -228,7 +228,7 @@
         </child>
         <child>
           <object class="GtkButton" id="reset_to_factory_settings">
-            <property name="label" translatable="yes">Destroy all user data and reset laptop to factory state (requires password)</property>
+            <property name="label" translatable="yes">Factory reset...</property>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
@@ -247,6 +247,124 @@
           <packing>
             <property name="left-attach">1</property>
             <property name="top-attach">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkDialog" id="target_chooser_dialog">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Confirmation of factory reset</property>
+    <property name="modal">True</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="type-hint">dialog</property>
+    <property name="urgency-hint">True</property>
+    <property name="deletable">False</property>
+    <property name="transient-for">app_window</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="target_chooser_dialog_button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="is-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="target_chooser_dialog_button_reset">
+                <property name="label" translatable="yes">Reset</property>
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="target_chooser_label_selection">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Select operating systems to reset:</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="target_checkbutton_puavo_os">
+            <property name="label" translatable="yes">Puavo OS</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="focus-on-click">False</property>
+            <property name="receives-default">False</property>
+            <property name="halign">center</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="target_checkbutton_windows">
+            <property name="label" translatable="yes">Windows</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="focus-on-click">False</property>
+            <property name="receives-default">False</property>
+            <property name="halign">center</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="target_chooser_label_warning">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="xpad">20</property>
+            <property name="ypad">20</property>
+            <property name="label" translatable="yes">&lt;big&gt;Factory reset &lt;span foreground="red" size="x-large"&gt;erases all user data&lt;/span&gt; from selected operating systems and restores their state to factory settings!&lt;/big&gt;</property>
+            <property name="use-markup">True</property>
+            <property name="justify">center</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
Replace old confirmation dialog with a new one which asks user to choose which operating systems to reset.

![kuva](https://github.com/puavo-org/puavo-os/assets/5660/93c1f602-34cf-477a-9dd1-c9d2ff488d04)

