### PR TITLE
Set max bpc by default to 8

### DIFF
--- a/parts/ltsp/client/lib/run-xrandr
+++ b/parts/ltsp/client/lib/run-xrandr
@@ -1,14 +1,20 @@
 #!/usr/bin/ruby
 
 require 'json'
+require 'optparse'
 require 'puavo/conf'
 require 'shellwords'
 require 'syslog'
 
+$has_max_bpc_been_set = false
 $monitors_info = nil
+$options = {
+  :only_set_max_bpc => false
+}
 $status = 0
 
 class MonitorsXMLSet < StandardError; end
+class OnlySetMaxBPC < StandardError; end
 
 def update_monitors_info
   xrandr_output = %x(xrandr -q)
@@ -187,7 +193,33 @@ def apply_settings(settings_to_apply, xrandr_parsed_args_list)
   end
 end
 
+def set_max_bpc_only_once()
+  if $has_max_bpc_been_set then
+    return
+  end
+
+  system('/usr/lib/puavo-ltsp-client/set-max-bpc')
+  set_max_bpc_status = $?.exitstatus
+
+  # One attempt is enough, no matter if it failed or not. Subsequent
+  # invocations would not magically yield any better results.
+  $has_max_bpc_been_set = true
+
+  if set_max_bpc_status != 0 then
+    Syslog.log(Syslog::LOG_ERR, "set-max-bpc FAILED")
+    $status = 1
+  else
+    Syslog.log(Syslog::LOG_INFO, "set-max-bpc ok")
+  end
+
+  if $options[:only_set_max_bpc] then
+    raise OnlySetMaxBPC
+  end
+end
+
 def run_xrandr(xrandr_args)
+  set_max_bpc_only_once
+
   system('xrandr', *xrandr_args)
   xrandr_status = $?.exitstatus
 
@@ -207,6 +239,23 @@ def run_xrandr(xrandr_args)
 end
 
 Syslog.open(File.basename($0), Syslog::LOG_CONS)
+
+OptionParser.new do |opts|
+  opts.banner = "
+  Usage: #{ File.basename(__FILE__) } [options]
+
+  Run xrandr if needed.
+  "
+
+  opts.on("--only-set-max-bpc", "Only set max bpc and exit") do
+    $options[:only_set_max_bpc] = true
+  end
+
+  opts.on_tail("-h", "--help", "Show this message") do
+    STDERR.puts opts
+    exit
+  end
+end.parse!
 
 begin
   deviceinfo = JSON.parse( File.read('/etc/puavo/device.json') )
@@ -258,6 +307,9 @@ begin
 rescue MonitorsXMLSet => e
   Syslog.log(Syslog::LOG_INFO,
              'not applying settings because monitors.xml is set in Puavo')
+rescue OnlySetMaxBPC => e
+  Syslog.log(Syslog::LOG_INFO,
+             'not applying settings because --only-set-max-bpc was used')
 rescue StandardError => e
   Syslog.log(Syslog::LOG_ERR, '%s', e.message)
   $status = 1

--- a/parts/ltsp/client/lib/set-max-bpc
+++ b/parts/ltsp/client/lib/set-max-bpc
@@ -4,9 +4,15 @@
 import argparse
 import collections
 import enum
+import logging
+import logging.handlers
 import re
 import subprocess
 import sys
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.INFO)
+_LOGGER.addHandler(logging.handlers.SysLogHandler("/dev/log"))
 
 
 class _State(str, enum.Enum):
@@ -216,18 +222,12 @@ def _main():
     try:
         desired_max_bpc = int(args.MAX_BPC, 10)
     except ValueError:
-        print(
-            f"error: invalid max bpc {args.MAX_BPC!r}, expected 10base integer",
-            file=sys.stderr,
-        )
+        _LOGGER.error("invalid max bpc %r, expected 10base integer", args.MAX_BPC)
         sys.exit(1)
 
     for output_name, output in _xrandr_get_prop().items():
         if "max bpc" in output["props"]:
-            print(
-                f"desired max bpc of {output_name!r} is {desired_max_bpc}",
-                file=sys.stderr,
-            )
+            _LOGGER.info("desired max bpc of %r is %d", output_name, desired_max_bpc)
 
             max_bpc_prop = output["props"]["max bpc"]
             current_value = max_bpc_prop["value"]
@@ -236,16 +236,22 @@ def _main():
 
             new_value = min(max(value_min, desired_max_bpc), value_max)
             if new_value != desired_max_bpc:
-                print(
-                    f"adjusted desired max bpc of {output_name!r} from {desired_max_bpc} to {new_value} to "
-                    f"match the supported range ({value_min}, {value_max})",
-                    file=sys.stderr,
+                _LOGGER.info(
+                    "adjusted desired max bpc of %r from %d to %d to "
+                    "match the supported range (%d, %d)",
+                    output_name,
+                    desired_max_bpc,
+                    new_value,
+                    value_min,
+                    value_max,
                 )
 
             _xrandr_set_max_bpc(output_name, new_value)
-            print(
-                f"set max bpc of {output_name!r} from {current_value} to {new_value}",
-                file=sys.stderr,
+            _LOGGER.info(
+                "set max bpc of %r from %d to %d",
+                output_name,
+                current_value,
+                new_value,
             )
 
 

--- a/parts/ltsp/client/lib/set-max-bpc
+++ b/parts/ltsp/client/lib/set-max-bpc
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+
+# Standard library imports
+import argparse
+import collections
+import enum
+import re
+import subprocess
+import sys
+
+
+class _State(str, enum.Enum):
+    DONE = "DONE"
+    INIT = "INIT"
+    NO_OUTPUTS = "NO_OUTPUTS"
+    OUTPUT = "OUTPUT"
+    OUTPUT_MODE = "OUTPUT_MODE"
+    OUTPUT_PROP = "OUTPUT_PROP"
+
+    def __str__(self):
+        return self.value
+
+    def __repr__(self):
+        return repr(self.value)
+
+
+class _TokenId(str, enum.Enum):
+    CONNECTOR = "CONNECTOR"
+    EOF = "EOF"
+    MODE = "MODE"
+    PROP_VALUE_CONTD = "PROP_VALUE_CONTD"
+    PROP_ATTR_RANGE = "PROP_ATTR_RANGE"
+    PROP_ATTR_SUPPORTED = "PROP_ATTR_SUPPORTED"
+    PROP_HEAD = "PROP_HEAD"
+    SCREEN = "SCREEN"
+
+    def __str__(self):
+        return self.value
+
+    def __repr__(self):
+        return repr(self.value)
+
+
+_TOKEN_REGEXES = collections.OrderedDict(
+    (
+        (
+            _TokenId.CONNECTOR,
+            r"^(?P<name>[^\s]+) (?P<state>connected|disconnected) .*$",
+        ),
+        (
+            _TokenId.EOF,
+            r"^$",
+        ),
+        (
+            _TokenId.MODE,
+            r"^   (?P<resolution>\d+x\d+) (?P<rates>.*?)\s*$",
+        ),
+        (
+            _TokenId.PROP_ATTR_RANGE,
+            r"^\t\trange: \((?P<value_min>\d+), (?P<value_max>\d+)\).*$",
+        ),
+        (
+            _TokenId.PROP_ATTR_SUPPORTED,
+            r"^\t\tsupported: (?P<supported_values>.*?)\s*$",
+        ),
+        (
+            _TokenId.PROP_VALUE_CONTD,
+            r"^\t\t(?P<value>.*?)\s*$",
+        ),
+        (
+            _TokenId.PROP_HEAD,
+            r"^\t(?P<name>[^:]+): (?P<value>.*?)\s*$",
+        ),
+        (
+            _TokenId.SCREEN,
+            r"^Screen (?P<number>\d+):.*$",
+        ),
+    )
+)
+
+
+def _tokenize(line):
+    for token_id, token_regex in _TOKEN_REGEXES.items():
+        token_match = re.match(token_regex, line)
+        if token_match is not None:
+            return token_id, token_match.groupdict()
+    raise ValueError("invalid line", line)
+
+
+class XRandrPropOutputParser:
+    def __init__(self):
+        self.__transitions = {
+            # (Current state, Input token): (Action, Next state)
+            (_State.INIT, _TokenId.SCREEN): (None, _State.NO_OUTPUTS),
+            (_State.NO_OUTPUTS, _TokenId.CONNECTOR): (
+                self.__action_create_output,
+                _State.OUTPUT,
+            ),
+            (_State.OUTPUT, _TokenId.PROP_HEAD): (
+                self.__action_create_prop,
+                _State.OUTPUT_PROP,
+            ),
+            (_State.OUTPUT_PROP, _TokenId.PROP_VALUE_CONTD): (
+                self.__action_append_prop_value,
+                _State.OUTPUT_PROP,
+            ),
+            (_State.OUTPUT_PROP, _TokenId.PROP_ATTR_RANGE): (
+                self.__action_add_prop_attr_range,
+                _State.OUTPUT_PROP,
+            ),
+            (_State.OUTPUT_PROP, _TokenId.PROP_ATTR_SUPPORTED): (
+                self.__action_add_prop_attr_supported,
+                _State.OUTPUT_PROP,
+            ),
+            (_State.OUTPUT_PROP, _TokenId.PROP_HEAD): (
+                self.__action_create_prop,
+                _State.OUTPUT_PROP,
+            ),
+            (_State.OUTPUT_PROP, _TokenId.CONNECTOR): (
+                self.__action_create_output,
+                _State.OUTPUT,
+            ),
+            (_State.OUTPUT_PROP, _TokenId.MODE): (None, _State.OUTPUT_MODE),
+            (_State.OUTPUT_PROP, _TokenId.EOF): (None, _State.DONE),
+            (_State.OUTPUT_MODE, _TokenId.MODE): (None, _State.OUTPUT_MODE),
+            (_State.OUTPUT_MODE, _TokenId.CONNECTOR): (
+                self.__action_create_output,
+                _State.OUTPUT,
+            ),
+            (_State.OUTPUT_MODE, _TokenId.EOF): (None, _State.DONE),
+        }
+        self.__current_state = _State.INIT
+        self.__displays = {}
+        self.__last_output = None
+        self.__last_prop = None
+
+    def __action_create_output(self, token_id, *, name, state):
+        if name in self.__displays:
+            raise RuntimeError("output is already defined", name)
+        self.__displays[name] = self.__last_output = {"name": name, "state": state}
+
+    def __action_create_prop(self, token_id, *, name, value):
+        self.__last_output.setdefault("props", {})[name] = self.__last_prop = {
+            "name": name,
+            "value": value,
+        }
+
+    def __action_append_prop_value(self, token_id, *, value):
+        self.__last_prop["value"] += value
+
+    def __action_add_prop_attr_range(self, token_id, *, value_min, value_max):
+        # Because this property has range attribute, it must be int.
+        self.__last_prop["value"] = int(self.__last_prop["value"], 10)
+        self.__last_prop["value_min"] = int(value_min, 10)
+        self.__last_prop["value_max"] = int(value_max, 10)
+
+    def __action_add_prop_attr_supported(self, token_id, supported_values):
+        self.__last_prop["supported_values"] = [
+            v.strip() for v in supported_values.split(",")
+        ]
+
+    def __push(self, token_id, token_groupdict):
+        action, next_state = self.__transitions[(self.__current_state, token_id)]
+        if action is not None:
+            action(token_id, **token_groupdict)
+        self.__current_state = next_state
+
+    def parse(self, xrandr_prop_output: str) -> dict:
+        for line in xrandr_prop_output.splitlines():
+            token_id, token_groupdict = _tokenize(line)
+            self.__push(token_id, token_groupdict)
+        self.__push(_TokenId.EOF, "")
+
+        return self.__displays
+
+
+def _xrandr_get_prop() -> dict:
+    xrandr_prop_output = subprocess.check_output(["xrandr", "--prop"]).decode("utf-8")
+    xrandr_prop_output_parser = XRandrPropOutputParser()
+
+    return xrandr_prop_output_parser.parse(xrandr_prop_output)
+
+
+def _xrandr_set_max_bpc(output_name: str, max_bpc: int):
+    subprocess.check_call(
+        [
+            "xrandr",
+            "--output",
+            output_name,
+            "--set",
+            "max bpc",
+            str(max_bpc),
+        ]
+    )
+
+
+def _main():
+    puavo_displays_max_bpc_str = (
+        subprocess.check_output(["puavo-conf", "puavo.displays.max_bpc"])
+        .decode("utf-8")
+        .strip()
+    )
+
+    argparser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Set max bpc of all displays.",
+    )
+    argparser.add_argument(
+        "MAX_BPC",
+        nargs="?",
+        help="If not given, puavo.displays.max_bpc value is used instead.",
+        default=puavo_displays_max_bpc_str,
+    )
+    args = argparser.parse_args()
+
+    try:
+        desired_max_bpc = int(args.MAX_BPC, 10)
+    except ValueError:
+        print(
+            f"error: invalid max bpc {args.MAX_BPC!r}, expected 10base integer",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    for output_name, output in _xrandr_get_prop().items():
+        if "max bpc" in output["props"]:
+            print(
+                f"desired max bpc of {output_name!r} is {desired_max_bpc}",
+                file=sys.stderr,
+            )
+
+            max_bpc_prop = output["props"]["max bpc"]
+            current_value = max_bpc_prop["value"]
+            value_min = max_bpc_prop["value_min"]
+            value_max = max_bpc_prop["value_max"]
+
+            new_value = min(max(value_min, desired_max_bpc), value_max)
+            if new_value != desired_max_bpc:
+                print(
+                    f"adjusted desired max bpc of {output_name!r} from {desired_max_bpc} to {new_value} to "
+                    f"match the supported range ({value_min}, {value_max})",
+                    file=sys.stderr,
+                )
+
+            _xrandr_set_max_bpc(output_name, new_value)
+            print(
+                f"set max bpc of {output_name!r} from {current_value} to {new_value}",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    _main()

--- a/parts/ltsp/client/lib/udev-hotplug-monitor
+++ b/parts/ltsp/client/lib/udev-hotplug-monitor
@@ -44,10 +44,12 @@ MUTTER_ALLOW_CONFIGURATION=$(
   lookup_env_for_pid MUTTER_ALLOW_CONFIGURATION "$current_session_pid") \
     || true
 
+run_xrandr_args=''
 if echo "$MUTTER_ALLOW_CONFIGURATION" | grep -Eqw '(default|user)'; then
   # mutter is taking care of monitors, or might be if user has configured
-  # it to do so... do not step on its tows.
-  exit 0
+  # it to do so... do not step on its tows, but still set max bpc
+
+  run_xrandr_args='--only-set-max-bpc'
 fi
 
 DISPLAY=$(lookup_env_for_pid DISPLAY "$current_session_pid")
@@ -55,4 +57,4 @@ XAUTHORITY=$(lookup_env_for_pid XAUTHORITY "$current_session_pid")
 
 export DISPLAY XAUTHORITY
 
-/usr/lib/puavo-ltsp-client/run-xrandr
+/usr/lib/puavo-ltsp-client/run-xrandr ${run_xrandr_args}

--- a/parts/ltsp/client/puavo-conf-parameters.json
+++ b/parts/ltsp/client/puavo-conf-parameters.json
@@ -60,6 +60,11 @@
     "description": "If true, force the monitors.xml display settings received from Puavo",
     "typehint": "string"
   },
+  "puavo.displays.max_bpc": {
+    "default": "8",
+    "description": "Max color depth (bits per color) for all displays",
+    "typehint": "integer"
+  },
   "puavo.displays.setup": {
     "choices": [ "all-mirror", "external", "builtin" ],
     "default": "all-mirror",


### PR DESCRIPTION
New library script `/usr/lib/puavo-ltsp-client/set-max-bpc` which sets max bpc of all display outputs according to `puavo.displays.max_bpc`, which defaults to `8`. `set-max-bpc` respects supported value ranges of each display output; if `puavo.displays.max_bpc` is below supported range, min value is set; if it's above supported range, max value is set.

`set-max-bpc` is called by `run-xrandr` but only when there are some changes to be applied. This avoids running costly `xrandr` unless there's a real need.