### PR TITLE
rules/apt: add i386 multiarch only if host arch is not i386

### DIFF
--- a/rules/apt/manifests/multiarch.pp
+++ b/rules/apt/manifests/multiarch.pp
@@ -11,7 +11,7 @@ class apt::multiarch {
     }
   }
 
-  if $architecture == 'amd64' {
+  if $deb_host_arch != 'i386' {
     ::apt::multiarch::addarch { 'i386': ; }
   }
 }

--- a/rules/debian/lib/facter/deb_host_arch.rb
+++ b/rules/debian/lib/facter/deb_host_arch.rb
@@ -1,0 +1,8 @@
+Facter.add('deb_host_arch') do
+  confine 'os' do |os|
+    os['family'] == 'Debian'
+  end
+  setcode do
+    Facter::Core::Execution.execute('/usr/bin/dpkg-architecture -q DEB_HOST_ARCH')
+  end
+end


### PR DESCRIPTION
    $architecture fact is the processor architecture
    $deb_host_arch is the dpkg architecture
    
    This makes i386 multiarch setup work correctly when built in i386 root
    with amd64 processor.
