### PR TITLE
debs/gnome-control-center: add icon theme chooser to appearance panel

### DIFF
--- a/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
+++ b/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
@@ -1,7 +1,7 @@
 From 2c4fcacd8ba6076f985f88b4587f123f10a8ceb5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 11:01:01 +0300
-Subject: [PATCH 1/3] [puavo] Disable user-accounts
+Subject: [PATCH 1/4] [puavo] Disable user-accounts
 
 ---
  shell/cc-panel-loader.c | 1 -

--- a/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
+++ b/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
@@ -1,7 +1,7 @@
 From 660bd4117b227d9f6a6e95410fff3ea5824e94b2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Sun, 21 Apr 2024 21:09:46 +0300
-Subject: [PATCH 2/3] [puavo] appearance: make style switch change themes too
+Subject: [PATCH 2/4] [puavo] appearance: make style switch change themes too
 
 ---
  panels/background/cc-background-panel.c | 101 +++++++++++++++++++++++-

--- a/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
+++ b/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
@@ -1,7 +1,7 @@
 From 647cd9487b42d9dc5d7e7e353ae2c0a1d0cc9bc0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 14:18:07 +0300
-Subject: [PATCH 3/3] [puavo] appearance: accept -dark as a valid dark theme
+Subject: [PATCH 3/4] [puavo] appearance: accept -dark as a valid dark theme
  prefix
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
+++ b/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
@@ -1,0 +1,469 @@
+From ca4a082e52b5e5ae053d937486fdb0f42801e6f6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Sun, 28 Apr 2024 21:43:21 +0300
+Subject: [PATCH 4/4] [puavo] appearance: add icon theme chooser
+
+---
+ panels/background/background.gresource.xml    |   2 +
+ panels/background/cc-background-panel.c       |   4 +
+ panels/background/cc-background-panel.ui      |  20 ++
+ panels/background/cc-icon-theme-chooser.c     | 237 ++++++++++++++++++
+ panels/background/cc-icon-theme-chooser.h     |  30 +++
+ panels/background/cc-icon-theme-chooser.ui    |  27 ++
+ .../icon-theme-selected-symbolic.svg          |   1 +
+ panels/background/meson.build                 |   2 +
+ panels/background/preview.css                 |   9 +
+ 9 files changed, 332 insertions(+)
+ create mode 100644 panels/background/cc-icon-theme-chooser.c
+ create mode 100644 panels/background/cc-icon-theme-chooser.h
+ create mode 100644 panels/background/cc-icon-theme-chooser.ui
+ create mode 100644 panels/background/icon-theme-selected-symbolic.svg
+
+diff --git a/panels/background/background.gresource.xml b/panels/background/background.gresource.xml
+index 1699244f0..ce26fb788 100644
+--- a/panels/background/background.gresource.xml
++++ b/panels/background/background.gresource.xml
+@@ -4,11 +4,13 @@
+     <file preprocess="xml-stripblanks">cc-background-chooser.ui</file>
+     <file preprocess="xml-stripblanks">cc-background-panel.ui</file>
+     <file preprocess="xml-stripblanks">cc-background-preview.ui</file>
++    <file preprocess="xml-stripblanks">cc-icon-theme-chooser.ui</file>
+     <file>preview.css</file>
+   </gresource>
+ 
+   <gresource prefix="/org/gnome/Settings/icons/scalable/actions">
+     <file preprocess="xml-stripblanks">background-selected-symbolic.svg</file>
++    <file preprocess="xml-stripblanks">icon-theme-selected-symbolic.svg</file>
+     <file preprocess="xml-stripblanks">slideshow-symbolic.svg</file>
+   </gresource>
+ </gresources>
+diff --git a/panels/background/cc-background-panel.c b/panels/background/cc-background-panel.c
+index b11ce6c2f..cae56ae30 100644
+--- a/panels/background/cc-background-panel.c
++++ b/panels/background/cc-background-panel.c
+@@ -35,6 +35,7 @@
+ #include "cc-background-preview.h"
+ #include "cc-background-resources.h"
+ #include "cc-background-xml.h"
++#include "cc-icon-theme-chooser.h"
+ 
+ #define WP_PATH_ID "org.gnome.desktop.background"
+ #define WP_LOCK_PATH_ID "org.gnome.desktop.screensaver"
+@@ -76,6 +77,7 @@ struct _CcBackgroundPanel
+   CcBackgroundPreview *dark_preview;
+   GtkToggleButton *default_toggle;
+   GtkToggleButton *dark_toggle;
++  CcIconThemeChooser *icon_theme_chooser;
+ };
+ 
+ static const gchar *const DARK_SUFFIXES[] = {"-Dark", "-dark"};
+@@ -486,6 +488,7 @@ cc_background_panel_class_init (CcBackgroundPanelClass *klass)
+ 
+   g_type_ensure (CC_TYPE_BACKGROUND_CHOOSER);
+   g_type_ensure (CC_TYPE_BACKGROUND_PREVIEW);
++  g_type_ensure (CC_TYPE_ICON_THEME_CHOOSER);
+ 
+   panel_class->get_help_uri = cc_background_panel_get_help_uri;
+ 
+@@ -499,6 +502,7 @@ cc_background_panel_class_init (CcBackgroundPanelClass *klass)
+   gtk_widget_class_bind_template_child (widget_class, CcBackgroundPanel, dark_preview);
+   gtk_widget_class_bind_template_child (widget_class, CcBackgroundPanel, default_toggle);
+   gtk_widget_class_bind_template_child (widget_class, CcBackgroundPanel, dark_toggle);
++  gtk_widget_class_bind_template_child (widget_class, CcBackgroundPanel, icon_theme_chooser);
+ 
+   gtk_widget_class_bind_template_callback (widget_class, on_color_scheme_toggle_active_cb);
+   gtk_widget_class_bind_template_callback (widget_class, on_chooser_background_chosen_cb);
+diff --git a/panels/background/cc-background-panel.ui b/panels/background/cc-background-panel.ui
+index 33a86385e..ce303a6f4 100644
+--- a/panels/background/cc-background-panel.ui
++++ b/panels/background/cc-background-panel.ui
+@@ -93,6 +93,26 @@
+           </object>
+         </child>
+ 
++        <child>
++          <object class="AdwPreferencesGroup">
++            <property name="title" translatable="yes">Icon theme</property>
++
++            <child>
++              <object class="AdwBin">
++                <style>
++                  <class name="card"/>
++                </style>
++                <child>
++                  <object class="CcIconThemeChooser" id="icon_theme_chooser">
++                    <property name="hexpand">True</property>
++                  </object>
++                </child>
++              </object>
++            </child>
++
++          </object>
++        </child>
++
+         <child>
+           <object class="AdwPreferencesGroup">
+             <property name="title" translatable="yes">Background</property>
+diff --git a/panels/background/cc-icon-theme-chooser.c b/panels/background/cc-icon-theme-chooser.c
+new file mode 100644
+index 000000000..667f859d4
+--- /dev/null
++++ b/panels/background/cc-icon-theme-chooser.c
+@@ -0,0 +1,237 @@
++/* cc-icon-theme-chooser.c
++ *
++ * Copyright 2024 Opinsys Oy
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation, either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ *
++ * SPDX-License-Identifier: GPL-3.0-or-later
++ */
++
++#undef G_LOG_DOMAIN
++#define G_LOG_DOMAIN "cc-icon-theme-chooser"
++
++#include <gtk/gtk.h>
++#include <glib/gi18n.h>
++#include <libgnome-desktop/gnome-desktop-thumbnail.h>
++
++#include "cc-icon-theme-chooser.h"
++
++enum {
++  ADWAITA,
++  FAENZA,
++  PAPIRUS,
++  TELA,
++  YARU,
++  ICON_THEME_COUNT,
++};
++
++static const gchar *const ICON_THEME_NAMES[ICON_THEME_COUNT]  = {"Adwaita", "Faenza", "Papirus", "Tela", "Yaru"};
++
++struct _CcIconThemeChooser
++{
++  GtkBox              parent;
++
++  GSettings          *interface_settings;
++  GtkFlowBox         *flowbox;
++  GtkWidget          *icon_theme_widgets[ICON_THEME_COUNT];
++};
++
++G_DEFINE_TYPE (CcIconThemeChooser, cc_icon_theme_chooser, GTK_TYPE_BOX)
++
++static GtkIconTheme*
++create_icon_theme (const gchar *const icon_theme_name)
++{
++  GtkIconTheme *icon_theme;
++  g_autofree gchar *search_path = NULL;
++
++  search_path = g_strconcat ("/usr/share/icons/", icon_theme_name, NULL);
++
++  icon_theme = gtk_icon_theme_new ();
++  gtk_icon_theme_set_theme_name (icon_theme, icon_theme_name);
++  gtk_icon_theme_add_search_path (icon_theme, search_path);
++
++  return icon_theme;
++}
++
++static GtkWidget*
++load_icon_theme_picture(const gchar *const icon_theme_name)
++{
++  g_autoptr(GtkIconTheme) icon_theme = create_icon_theme (icon_theme_name);
++  g_autoptr(GtkIconPaintable) icon_paintable = NULL;
++  GtkWidget *picture;
++
++  icon_paintable = gtk_icon_theme_lookup_icon (icon_theme,
++                                               "folder",
++                                               NULL,
++                                               96,
++                                               1,
++                                               GTK_TEXT_DIR_NONE,
++                                               GTK_ICON_LOOKUP_FORCE_REGULAR);
++
++  picture = gtk_picture_new_for_paintable (GDK_PAINTABLE (icon_paintable));
++  gtk_picture_set_can_shrink (GTK_PICTURE (picture), FALSE);
++
++  return picture;
++}
++
++static GtkWidget*
++create_flow_box_child(const gchar *const icon_theme_name)
++{
++  GtkWidget *check;
++  GtkWidget *child;
++  GtkWidget *overlay;
++  GtkWidget *picture;
++
++  picture = load_icon_theme_picture (icon_theme_name);
++
++  check = gtk_image_new_from_icon_name ("icon-theme-selected-symbolic");
++  gtk_widget_set_halign (check, GTK_ALIGN_END);
++  gtk_widget_set_valign (check, GTK_ALIGN_END);
++  gtk_widget_add_css_class (check, "selected-check");
++
++  overlay = gtk_overlay_new ();
++  gtk_widget_set_overflow (overlay, GTK_OVERFLOW_HIDDEN);
++  gtk_widget_add_css_class (overlay, "icon-theme-thumbnail");
++  gtk_overlay_set_child (GTK_OVERLAY (overlay), picture);
++  gtk_overlay_add_overlay (GTK_OVERLAY (overlay), check);
++
++  child = gtk_flow_box_child_new ();
++  gtk_widget_set_halign (child, GTK_ALIGN_CENTER);
++  gtk_widget_set_valign (child, GTK_ALIGN_CENTER);
++  gtk_flow_box_child_set_child (GTK_FLOW_BOX_CHILD (child), overlay);
++
++  gtk_widget_set_tooltip_text (child, icon_theme_name);
++
++  return child;
++}
++
++static void
++setup_flowbox (CcIconThemeChooser *self)
++{
++  GtkWidget *child;
++  int i;
++
++  for (i = 0; i < ICON_THEME_COUNT; ++i)
++    {
++      child = create_flow_box_child (ICON_THEME_NAMES[i]);
++      self->icon_theme_widgets[i] = child;
++      gtk_flow_box_append (self->flowbox, child);
++    }
++
++  gtk_flow_box_set_max_children_per_line(self->flowbox, ICON_THEME_COUNT);
++}
++
++static void
++set_icon_theme_by_name (CcIconThemeChooser *self,
++                        const gchar *const icon_theme_name)
++{
++  g_assert (icon_theme_name != NULL);
++
++  g_autoptr(GtkIconTheme) icon_theme = create_icon_theme (icon_theme_name);
++
++  g_settings_set_string (self->interface_settings,
++                         "icon-theme",
++                         icon_theme_name);
++  g_settings_apply (self->interface_settings);
++}
++
++static void
++on_icon_theme_activated_cb (GtkFlowBox          *flowbox,
++                            GtkFlowBoxChild     *child,
++                            CcIconThemeChooser  *self)
++{
++  int i = gtk_flow_box_child_get_index(child);
++  g_assert (i >= 0 && i < ICON_THEME_COUNT);
++
++  set_icon_theme_by_name (self, ICON_THEME_NAMES[i]);
++}
++
++static void
++select_current_icon_theme (CcIconThemeChooser *self)
++{
++  GtkFlowBoxChild *flow_box_child;
++  int i;
++  g_autofree gchar *icon_theme_name = NULL;
++
++  gtk_flow_box_unselect_all(self->flowbox);
++
++  icon_theme_name = g_settings_get_string (self->interface_settings, "icon-theme");
++
++  if (!icon_theme_name)
++    return;
++
++  for (i = 0; i < ICON_THEME_COUNT; ++i)
++    {
++      if (g_strcmp0(icon_theme_name, ICON_THEME_NAMES[i]) != 0)
++        continue;
++
++      flow_box_child = gtk_flow_box_get_child_at_index(self->flowbox, i);
++      g_assert (flow_box_child != NULL);
++      gtk_flow_box_select_child(self->flowbox, flow_box_child);
++      break;
++    }
++}
++
++/* GObject overrides */
++
++static void
++cc_icon_theme_chooser_dispose (GObject *object)
++{
++  CcIconThemeChooser *self = CC_ICON_THEME_CHOOSER (object);
++
++  g_clear_object (&self->interface_settings);
++
++  G_OBJECT_CLASS (cc_icon_theme_chooser_parent_class)->dispose (object);
++}
++
++static void
++cc_icon_theme_chooser_finalize (GObject *object)
++{
++  G_OBJECT_CLASS (cc_icon_theme_chooser_parent_class)->finalize (object);
++}
++
++static void
++cc_icon_theme_chooser_class_init (CcIconThemeChooserClass *klass)
++{
++  GObjectClass *object_class = G_OBJECT_CLASS (klass);
++  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
++
++  object_class->dispose = cc_icon_theme_chooser_dispose;
++  object_class->finalize = cc_icon_theme_chooser_finalize;
++
++  gtk_widget_class_set_template_from_resource (widget_class,
++                                               "/org/gnome/control-center/background/cc-icon-theme-chooser.ui");
++
++  gtk_widget_class_bind_template_child (widget_class, CcIconThemeChooser, flowbox);
++
++  gtk_widget_class_bind_template_callback (widget_class, on_icon_theme_activated_cb);
++}
++
++static void
++cc_icon_theme_chooser_init (CcIconThemeChooser *self)
++{
++  gtk_widget_init_template (GTK_WIDGET (self));
++
++  self->interface_settings = g_settings_new ("org.gnome.desktop.interface");
++
++  setup_flowbox (self);
++
++  g_signal_connect_object (self->interface_settings,
++                           "changed::icon-theme",
++                           G_CALLBACK (select_current_icon_theme),
++                           self,
++                           G_CONNECT_SWAPPED);
++
++  select_current_icon_theme(self);
++}
+diff --git a/panels/background/cc-icon-theme-chooser.h b/panels/background/cc-icon-theme-chooser.h
+new file mode 100644
+index 000000000..4f79e9b01
+--- /dev/null
++++ b/panels/background/cc-icon-theme-chooser.h
+@@ -0,0 +1,30 @@
++/* cc-icon-theme-chooser.h
++ *
++ * Copyright 2024 Opinsys Oy
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation, either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ *
++ * SPDX-License-Identifier: GPL-3.0-or-later
++ */
++
++#pragma once
++
++#include <gtk/gtk.h>
++
++G_BEGIN_DECLS
++
++#define CC_TYPE_ICON_THEME_CHOOSER (cc_icon_theme_chooser_get_type())
++G_DECLARE_FINAL_TYPE (CcIconThemeChooser, cc_icon_theme_chooser, CC, ICON_THEME_CHOOSER, GtkBox)
++
++G_END_DECLS
+diff --git a/panels/background/cc-icon-theme-chooser.ui b/panels/background/cc-icon-theme-chooser.ui
+new file mode 100644
+index 000000000..7b201b1fb
+--- /dev/null
++++ b/panels/background/cc-icon-theme-chooser.ui
+@@ -0,0 +1,27 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<interface>
++  <template class="CcIconThemeChooser" parent="GtkBox">
++    <property name="orientation">vertical</property>
++
++    <child>
++      <object class="GtkFlowBox" id="flowbox">
++        <property name="margin-top">12</property>
++        <property name="margin-bottom">12</property>
++        <property name="margin-start">12</property>
++        <property name="margin-end">12</property>
++        <property name="column-spacing">12</property>
++        <property name="row-spacing">12</property>
++        <property name="homogeneous">True</property>
++        <property name="halign">center</property>
++        <property name="min-children-per-line">1</property>
++        <property name="activate-on-single-click">True</property>
++        <property name="selection-mode">single</property>
++        <signal name="child-activated" handler="on_icon_theme_activated_cb" object="CcIconThemeChooser" swapped="no" />
++        <style>
++          <class name="icon-theme-flowbox"/>
++        </style>
++      </object>
++    </child>
++
++  </template>
++</interface>
+diff --git a/panels/background/icon-theme-selected-symbolic.svg b/panels/background/icon-theme-selected-symbolic.svg
+new file mode 100644
+index 000000000..9e820d1dc
+--- /dev/null
++++ b/panels/background/icon-theme-selected-symbolic.svg
+@@ -0,0 +1 @@
++<svg width="16" height="16" viewBox="0 0 4.233 4.233" xmlns="http://www.w3.org/2000/svg"><path d="M3.843.627a.397.397 0 0 0-.56.034L1.45 2.73l-.775-.763a.397.397 0 0 0-.56.004.397.397 0 0 0 .003.562L1.191 3.59a.397.397 0 0 0 .576-.02l2.11-2.382a.397.397 0 0 0-.034-.56Z" style="fill:#3d3846"/></svg>
+\ No newline at end of file
+diff --git a/panels/background/meson.build b/panels/background/meson.build
+index 3634c4727..2756cc328 100644
+--- a/panels/background/meson.build
++++ b/panels/background/meson.build
+@@ -52,6 +52,7 @@ resource_data = files(
+   'cc-background-chooser.ui',
+   'cc-background-panel.ui',
+   'cc-background-preview.ui',
++  'cc-icon-theme-chooser.ui',
+   'preview.css',
+ )
+ 
+@@ -74,6 +75,7 @@ sources = common_sources + files(
+   'cc-background-panel.c',
+   'cc-background-preview.c',
+   'cc-background-xml.c',
++  'cc-icon-theme-chooser.c',
+ )
+ 
+ deps = common_deps + [
+diff --git a/panels/background/preview.css b/panels/background/preview.css
+index e9497348b..7d95f8294 100644
+--- a/panels/background/preview.css
++++ b/panels/background/preview.css
+@@ -69,6 +69,15 @@ background-preview .window.front.dark .header-bar {
+   border-radius: 6px;
+ }
+ 
++.icon-theme-flowbox > flowboxchild {
++  background: none;
++  border-radius: 9px;
++}
++
++.icon-theme-thumbnail {
++  border-radius: 6px;
++}
++
+ .slideshow-icon {
+   color: white;
+   -gtk-icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.33);
+-- 
+2.39.2
+


### PR DESCRIPTION
Patch formatted from: https://github.com/puavo-org/gnome-control-center/commit/ca4a082e52b5e5ae053d937486fdb0f42801e6f6