### PR TITLE
debs/gnome-control-center: add icon theme -related translations and icon theme labels

### DIFF
--- a/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
+++ b/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
@@ -1,7 +1,7 @@
 From 2c4fcacd8ba6076f985f88b4587f123f10a8ceb5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 11:01:01 +0300
-Subject: [PATCH 1/4] [puavo] Disable user-accounts
+Subject: [PATCH 1/7] [puavo] Disable user-accounts
 
 ---
  shell/cc-panel-loader.c | 1 -

--- a/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
+++ b/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
@@ -1,7 +1,7 @@
 From 660bd4117b227d9f6a6e95410fff3ea5824e94b2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Sun, 21 Apr 2024 21:09:46 +0300
-Subject: [PATCH 2/4] [puavo] appearance: make style switch change themes too
+Subject: [PATCH 2/7] [puavo] appearance: make style switch change themes too
 
 ---
  panels/background/cc-background-panel.c | 101 +++++++++++++++++++++++-

--- a/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
+++ b/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
@@ -1,7 +1,7 @@
 From 647cd9487b42d9dc5d7e7e353ae2c0a1d0cc9bc0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 14:18:07 +0300
-Subject: [PATCH 3/4] [puavo] appearance: accept -dark as a valid dark theme
+Subject: [PATCH 3/7] [puavo] appearance: accept -dark as a valid dark theme
  prefix
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
+++ b/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
@@ -1,7 +1,7 @@
 From ca4a082e52b5e5ae053d937486fdb0f42801e6f6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Sun, 28 Apr 2024 21:43:21 +0300
-Subject: [PATCH 4/4] [puavo] appearance: add icon theme chooser
+Subject: [PATCH 4/7] [puavo] appearance: add icon theme chooser
 
 ---
  panels/background/background.gresource.xml    |   2 +

--- a/debs/gnome-control-center/puavo/patches/0005-puavo-Update-translations-fi-sv-de.patch
+++ b/debs/gnome-control-center/puavo/patches/0005-puavo-Update-translations-fi-sv-de.patch
@@ -1,0 +1,74 @@
+From fd2d1c5dddd2994d4e3071a24aecf1e60d098b0e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Mon, 29 Apr 2024 18:42:03 +0300
+Subject: [PATCH 5/7] [puavo] Update translations fi, sv, de
+
+---
+ po/de.po | 6 +++++-
+ po/fi.po | 6 +++++-
+ po/sv.po | 6 +++++-
+ 3 files changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/po/de.po b/po/de.po
+index f6fea8c92..6d7a7fd8e 100644
+--- a/po/de.po
++++ b/po/de.po
+@@ -441,10 +441,14 @@ msgid "Dark"
+ msgstr "Dunkel"
+ 
+ #: panels/background/cc-background-panel.ui:98
++msgid "Icon theme"
++msgstr "Icon Thema"
++
++#: panels/background/cc-background-panel.ui:118
+ msgid "Background"
+ msgstr "Hintergrund"
+ 
+-#: panels/background/cc-background-panel.ui:104
++#: panels/background/cc-background-panel.ui:124
+ msgid "Add Picture…"
+ msgstr "Bild hinzufügen …"
+ 
+diff --git a/po/fi.po b/po/fi.po
+index 01a88c777..0b00148bb 100644
+--- a/po/fi.po
++++ b/po/fi.po
+@@ -438,10 +438,14 @@ msgid "Dark"
+ msgstr "Tumma"
+ 
+ #: panels/background/cc-background-panel.ui:98
++msgid "Icon theme"
++msgstr "Kuvaketeema"
++
++#: panels/background/cc-background-panel.ui:118
+ msgid "Background"
+ msgstr "Taustakuva"
+ 
+-#: panels/background/cc-background-panel.ui:104
++#: panels/background/cc-background-panel.ui:124
+ msgid "Add Picture…"
+ msgstr "Lisää kuva…"
+ 
+diff --git a/po/sv.po b/po/sv.po
+index def284af1..1fe298086 100644
+--- a/po/sv.po
++++ b/po/sv.po
+@@ -424,10 +424,14 @@ msgid "Dark"
+ msgstr "Mörk"
+ 
+ #: panels/background/cc-background-panel.ui:98
++msgid "Icon theme"
++msgstr "Ikon tema"
++
++#: panels/background/cc-background-panel.ui:118
+ msgid "Background"
+ msgstr "Bakgrund"
+ 
+-#: panels/background/cc-background-panel.ui:104
++#: panels/background/cc-background-panel.ui:124
+ msgid "Add Picture…"
+ msgstr "Lägg till bild…"
+ 
+-- 
+2.39.2
+

--- a/debs/gnome-control-center/puavo/patches/0006-puavo-appearance-tighten-icon-chooser-layout-to-fit-.patch
+++ b/debs/gnome-control-center/puavo/patches/0006-puavo-appearance-tighten-icon-chooser-layout-to-fit-.patch
@@ -1,0 +1,36 @@
+From 1d6951c9a938cbf18ef525b52bf030f8be8c924a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Mon, 29 Apr 2024 19:15:57 +0300
+Subject: [PATCH 6/7] [puavo] appearance: tighten icon chooser layout to fit
+ all 5 icon themes on the same row
+
+---
+ panels/background/cc-icon-theme-chooser.ui | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/panels/background/cc-icon-theme-chooser.ui b/panels/background/cc-icon-theme-chooser.ui
+index 7b201b1fb..c6c9e38fd 100644
+--- a/panels/background/cc-icon-theme-chooser.ui
++++ b/panels/background/cc-icon-theme-chooser.ui
+@@ -5,12 +5,12 @@
+ 
+     <child>
+       <object class="GtkFlowBox" id="flowbox">
+-        <property name="margin-top">12</property>
+-        <property name="margin-bottom">12</property>
+-        <property name="margin-start">12</property>
+-        <property name="margin-end">12</property>
+-        <property name="column-spacing">12</property>
+-        <property name="row-spacing">12</property>
++        <property name="margin-top">3</property>
++        <property name="margin-bottom">3</property>
++        <property name="margin-start">3</property>
++        <property name="margin-end">3</property>
++        <property name="column-spacing">3</property>
++        <property name="row-spacing">3</property>
+         <property name="homogeneous">True</property>
+         <property name="halign">center</property>
+         <property name="min-children-per-line">1</property>
+-- 
+2.39.2
+

--- a/debs/gnome-control-center/puavo/patches/0007-puavo-appearance-add-icon-theme-labels.patch
+++ b/debs/gnome-control-center/puavo/patches/0007-puavo-appearance-add-icon-theme-labels.patch
@@ -1,0 +1,48 @@
+From d5d48282a3ffa3faee0059a0668ff35743bb8098 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Mon, 29 Apr 2024 19:16:44 +0300
+Subject: [PATCH 7/7] [puavo] appearance: add icon theme labels
+
+---
+ panels/background/cc-icon-theme-chooser.c | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/panels/background/cc-icon-theme-chooser.c b/panels/background/cc-icon-theme-chooser.c
+index 667f859d4..c5b8cf13e 100644
+--- a/panels/background/cc-icon-theme-chooser.c
++++ b/panels/background/cc-icon-theme-chooser.c
+@@ -92,6 +92,7 @@ create_flow_box_child(const gchar *const icon_theme_name)
+   GtkWidget *child;
+   GtkWidget *overlay;
+   GtkWidget *picture;
++  GtkWidget *grid;
+ 
+   picture = load_icon_theme_picture (icon_theme_name);
+ 
+@@ -106,10 +107,22 @@ create_flow_box_child(const gchar *const icon_theme_name)
+   gtk_overlay_set_child (GTK_OVERLAY (overlay), picture);
+   gtk_overlay_add_overlay (GTK_OVERLAY (overlay), check);
+ 
++  grid = gtk_grid_new ();
++  gtk_grid_set_column_homogeneous (GTK_GRID (grid), TRUE);
++  gtk_grid_set_column_spacing (GTK_GRID (grid), 3);
++  gtk_grid_set_row_spacing (GTK_GRID (grid), 3);
++  gtk_widget_set_margin_start (grid, 3);
++  gtk_widget_set_margin_end (grid, 3);
++  gtk_widget_set_margin_top (grid, 3);
++  gtk_widget_set_margin_bottom (grid, 3);
++  gtk_widget_set_hexpand (grid, TRUE);
++  gtk_grid_attach (GTK_GRID (grid), overlay, 0, 0, 1, 1);
++  gtk_grid_attach (GTK_GRID (grid), gtk_label_new (icon_theme_name), 0, 1, 1, 1);
++
+   child = gtk_flow_box_child_new ();
+   gtk_widget_set_halign (child, GTK_ALIGN_CENTER);
+   gtk_widget_set_valign (child, GTK_ALIGN_CENTER);
+-  gtk_flow_box_child_set_child (GTK_FLOW_BOX_CHILD (child), overlay);
++  gtk_flow_box_child_set_child (GTK_FLOW_BOX_CHILD (child), grid);
+ 
+   gtk_widget_set_tooltip_text (child, icon_theme_name);
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
[[puavo] Update translations fi, sv, de](https://github.com/puavo-org/gnome-control-center/commit/fd2d1c5dddd2994d4e3071a24aecf1e60d098b0e)

[[puavo] appearance: tighten icon chooser layout to fit all 5 icon themes on the same row](https://github.com/puavo-org/gnome-control-center/commit/1d6951c9a938cbf18ef525b52bf030f8be8c924a)

[[puavo] appearance: add icon theme labels](https://github.com/puavo-org/gnome-control-center/commit/d5d48282a3ffa3faee0059a0668ff35743bb8098)