### PR TITLE
debs/gnome-control-center: switch gtk theme and shell theme independently

### DIFF
--- a/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
+++ b/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
@@ -1,7 +1,7 @@
 From 2c4fcacd8ba6076f985f88b4587f123f10a8ceb5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 11:01:01 +0300
-Subject: [PATCH 1/7] [puavo] Disable user-accounts
+Subject: [PATCH 1/8] [puavo] Disable user-accounts
 
 ---
  shell/cc-panel-loader.c | 1 -

--- a/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
+++ b/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
@@ -1,7 +1,7 @@
 From 660bd4117b227d9f6a6e95410fff3ea5824e94b2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Sun, 21 Apr 2024 21:09:46 +0300
-Subject: [PATCH 2/7] [puavo] appearance: make style switch change themes too
+Subject: [PATCH 2/8] [puavo] appearance: make style switch change themes too
 
 ---
  panels/background/cc-background-panel.c | 101 +++++++++++++++++++++++-

--- a/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
+++ b/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
@@ -1,7 +1,7 @@
 From 647cd9487b42d9dc5d7e7e353ae2c0a1d0cc9bc0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 14:18:07 +0300
-Subject: [PATCH 3/7] [puavo] appearance: accept -dark as a valid dark theme
+Subject: [PATCH 3/8] [puavo] appearance: accept -dark as a valid dark theme
  prefix
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
+++ b/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
@@ -1,7 +1,7 @@
 From ca4a082e52b5e5ae053d937486fdb0f42801e6f6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Sun, 28 Apr 2024 21:43:21 +0300
-Subject: [PATCH 4/7] [puavo] appearance: add icon theme chooser
+Subject: [PATCH 4/8] [puavo] appearance: add icon theme chooser
 
 ---
  panels/background/background.gresource.xml    |   2 +

--- a/debs/gnome-control-center/puavo/patches/0005-puavo-Update-translations-fi-sv-de.patch
+++ b/debs/gnome-control-center/puavo/patches/0005-puavo-Update-translations-fi-sv-de.patch
@@ -1,7 +1,7 @@
 From fd2d1c5dddd2994d4e3071a24aecf1e60d098b0e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Mon, 29 Apr 2024 18:42:03 +0300
-Subject: [PATCH 5/7] [puavo] Update translations fi, sv, de
+Subject: [PATCH 5/8] [puavo] Update translations fi, sv, de
 
 ---
  po/de.po | 6 +++++-

--- a/debs/gnome-control-center/puavo/patches/0006-puavo-appearance-tighten-icon-chooser-layout-to-fit-.patch
+++ b/debs/gnome-control-center/puavo/patches/0006-puavo-appearance-tighten-icon-chooser-layout-to-fit-.patch
@@ -1,7 +1,7 @@
 From 1d6951c9a938cbf18ef525b52bf030f8be8c924a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Mon, 29 Apr 2024 19:15:57 +0300
-Subject: [PATCH 6/7] [puavo] appearance: tighten icon chooser layout to fit
+Subject: [PATCH 6/8] [puavo] appearance: tighten icon chooser layout to fit
  all 5 icon themes on the same row
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0007-puavo-appearance-add-icon-theme-labels.patch
+++ b/debs/gnome-control-center/puavo/patches/0007-puavo-appearance-add-icon-theme-labels.patch
@@ -1,7 +1,7 @@
 From d5d48282a3ffa3faee0059a0668ff35743bb8098 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Mon, 29 Apr 2024 19:16:44 +0300
-Subject: [PATCH 7/7] [puavo] appearance: add icon theme labels
+Subject: [PATCH 7/8] [puavo] appearance: add icon theme labels
 
 ---
  panels/background/cc-icon-theme-chooser.c | 15 ++++++++++++++-

--- a/debs/gnome-control-center/puavo/patches/0008-puavo-appearance-set-Shell-theme-and-GTK-theme-indep.patch
+++ b/debs/gnome-control-center/puavo/patches/0008-puavo-appearance-set-Shell-theme-and-GTK-theme-indep.patch
@@ -1,0 +1,83 @@
+From 89f920ff8041d09050dcdb65262f2b3c6f994d1c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Wed, 15 May 2024 23:07:40 +0300
+Subject: [PATCH 8/8] [puavo] appearance: set Shell theme and GTK theme
+ independently
+
+---
+ panels/background/cc-background-panel.c | 35 +++++++++++++------------
+ 1 file changed, 18 insertions(+), 17 deletions(-)
+
+diff --git a/panels/background/cc-background-panel.c b/panels/background/cc-background-panel.c
+index cae56ae30..9814f88a0 100644
+--- a/panels/background/cc-background-panel.c
++++ b/panels/background/cc-background-panel.c
+@@ -209,25 +209,28 @@ set_color_scheme (CcBackgroundPanel   *self,
+ {
+   g_autofree gchar *current_gtk_theme = NULL;
+   g_autofree gchar *current_shell_theme = NULL;
+-  g_autofree gchar *next_theme = NULL;
++  g_autofree gchar *next_gtk_theme = NULL;
++  g_autofree gchar *next_shell_theme = NULL;
+   GDesktopColorScheme scheme;
+ 
+   scheme = g_settings_get_enum (self->interface_settings,
+                                 INTERFACE_COLOR_SCHEME_KEY);
+   current_gtk_theme = g_settings_get_string (self->interface_settings,
+                                              INTERFACE_GTK_THEME_KEY);
++  next_gtk_theme = get_next_theme(current_gtk_theme, color_scheme);
++
+   if (self->maybe_user_theme_settings)
+   {
+     current_shell_theme = g_settings_get_string (self->maybe_user_theme_settings,
+                                                  USER_THEME_NAME_KEY);
++    next_shell_theme = get_next_theme(current_shell_theme, color_scheme);
+   }
+-  next_theme = get_next_theme(current_gtk_theme, color_scheme);
+ 
+   /* We have to check the equality manually to avoid starting an unnecessary
+    * screen transition */
+   if (color_scheme == scheme
+-      && g_strcmp0(current_gtk_theme, next_theme) == 0
+-      && (self->maybe_user_theme_settings == NULL || g_strcmp0(current_shell_theme, next_theme) == 0))
++      && g_strcmp0(current_gtk_theme, next_gtk_theme) == 0
++      && (self->maybe_user_theme_settings == NULL || g_strcmp0(current_shell_theme, next_shell_theme) == 0))
+     return;
+ 
+   transition_screen (self);
+@@ -236,21 +239,19 @@ set_color_scheme (CcBackgroundPanel   *self,
+                        INTERFACE_COLOR_SCHEME_KEY,
+                        color_scheme);
+ 
+-  if (!next_theme)
+-  {
+-    g_warning ("Next theme is not defined, not changing theme");
+-    return;
+-  }
++  if (next_gtk_theme)
++    g_settings_set_string (self->interface_settings, INTERFACE_GTK_THEME_KEY, next_gtk_theme);
++  else
++    g_warning ("Next GTK theme is not defined, not changing GTK theme");
++
+ 
+-  g_settings_set_string (self->interface_settings,
+-                         INTERFACE_GTK_THEME_KEY,
+-                         next_theme);
+   if (self->maybe_user_theme_settings)
+-  {
+-    g_settings_set_string (self->maybe_user_theme_settings,
+-                           USER_THEME_NAME_KEY,
+-                           next_theme);
+-  }
++    {
++      if (next_shell_theme)
++        g_settings_set_string (self->maybe_user_theme_settings, USER_THEME_NAME_KEY, next_shell_theme);
++      else
++        g_warning ("Next Shell theme is not defined, not changing Shell theme");
++    }
+ }
+ 
+ /* Color schemes */
+-- 
+2.39.2
+


### PR DESCRIPTION
Patch picked from: https://github.com/puavo-org/gnome-control-center/commit/89f920ff8041d09050dcdb65262f2b3c6f994d1c

How to test our "upstream" directly:
```
git clone git@github.com:puavo-org/gnome-control-center.git
cd gnome-control-center
git checkout puavo_gnome_control_center_43.6
sudo apt install libcups2=2.4.2-3+deb12u5
sudo apt build-dep gnome-control-center
cd parts/gnome-control-center
meson setup builddir
ninja -C builddir
builddir/shell/gnome-control-center
```