### PR TITLE
debs/gnome-control-center: change also Qt theme when color scheme is changed

### DIFF
--- a/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
+++ b/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
@@ -1,7 +1,7 @@
 From 2c4fcacd8ba6076f985f88b4587f123f10a8ceb5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 11:01:01 +0300
-Subject: [PATCH 1/8] [puavo] Disable user-accounts
+Subject: [PATCH 01/11] [puavo] Disable user-accounts
 
 ---
  shell/cc-panel-loader.c | 1 -

--- a/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
+++ b/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
@@ -1,7 +1,7 @@
 From 660bd4117b227d9f6a6e95410fff3ea5824e94b2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Sun, 21 Apr 2024 21:09:46 +0300
-Subject: [PATCH 2/8] [puavo] appearance: make style switch change themes too
+Subject: [PATCH 02/11] [puavo] appearance: make style switch change themes too
 
 ---
  panels/background/cc-background-panel.c | 101 +++++++++++++++++++++++-

--- a/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
+++ b/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
@@ -1,7 +1,7 @@
 From 647cd9487b42d9dc5d7e7e353ae2c0a1d0cc9bc0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 14:18:07 +0300
-Subject: [PATCH 3/8] [puavo] appearance: accept -dark as a valid dark theme
+Subject: [PATCH 03/11] [puavo] appearance: accept -dark as a valid dark theme
  prefix
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
+++ b/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
@@ -1,7 +1,7 @@
 From ca4a082e52b5e5ae053d937486fdb0f42801e6f6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Sun, 28 Apr 2024 21:43:21 +0300
-Subject: [PATCH 4/8] [puavo] appearance: add icon theme chooser
+Subject: [PATCH 04/11] [puavo] appearance: add icon theme chooser
 
 ---
  panels/background/background.gresource.xml    |   2 +

--- a/debs/gnome-control-center/puavo/patches/0005-puavo-Update-translations-fi-sv-de.patch
+++ b/debs/gnome-control-center/puavo/patches/0005-puavo-Update-translations-fi-sv-de.patch
@@ -1,7 +1,7 @@
 From fd2d1c5dddd2994d4e3071a24aecf1e60d098b0e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Mon, 29 Apr 2024 18:42:03 +0300
-Subject: [PATCH 5/8] [puavo] Update translations fi, sv, de
+Subject: [PATCH 05/11] [puavo] Update translations fi, sv, de
 
 ---
  po/de.po | 6 +++++-

--- a/debs/gnome-control-center/puavo/patches/0006-puavo-appearance-tighten-icon-chooser-layout-to-fit-.patch
+++ b/debs/gnome-control-center/puavo/patches/0006-puavo-appearance-tighten-icon-chooser-layout-to-fit-.patch
@@ -1,7 +1,7 @@
 From 1d6951c9a938cbf18ef525b52bf030f8be8c924a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Mon, 29 Apr 2024 19:15:57 +0300
-Subject: [PATCH 6/8] [puavo] appearance: tighten icon chooser layout to fit
+Subject: [PATCH 06/11] [puavo] appearance: tighten icon chooser layout to fit
  all 5 icon themes on the same row
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0007-puavo-appearance-add-icon-theme-labels.patch
+++ b/debs/gnome-control-center/puavo/patches/0007-puavo-appearance-add-icon-theme-labels.patch
@@ -1,7 +1,7 @@
 From d5d48282a3ffa3faee0059a0668ff35743bb8098 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Mon, 29 Apr 2024 19:16:44 +0300
-Subject: [PATCH 7/8] [puavo] appearance: add icon theme labels
+Subject: [PATCH 07/11] [puavo] appearance: add icon theme labels
 
 ---
  panels/background/cc-icon-theme-chooser.c | 15 ++++++++++++++-

--- a/debs/gnome-control-center/puavo/patches/0008-puavo-appearance-set-Shell-theme-and-GTK-theme-indep.patch
+++ b/debs/gnome-control-center/puavo/patches/0008-puavo-appearance-set-Shell-theme-and-GTK-theme-indep.patch
@@ -1,7 +1,7 @@
 From 89f920ff8041d09050dcdb65262f2b3c6f994d1c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Wed, 15 May 2024 23:07:40 +0300
-Subject: [PATCH 8/8] [puavo] appearance: set Shell theme and GTK theme
+Subject: [PATCH 08/11] [puavo] appearance: set Shell theme and GTK theme
  independently
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0009-puavo-appearance-change-theme-existence-check-to-tes.patch
+++ b/debs/gnome-control-center/puavo/patches/0009-puavo-appearance-change-theme-existence-check-to-tes.patch
@@ -1,0 +1,37 @@
+From 9dd2bef9ed7e14e19d613852e37be7f2e8ba381d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Fri, 17 May 2024 18:04:39 +0300
+Subject: [PATCH 09/11] [puavo] appearance: change theme existence check to
+ test only the existence of theme dir
+
+Not all themes have index.theme files, e.g KvArc.
+---
+ panels/background/cc-background-panel.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/panels/background/cc-background-panel.c b/panels/background/cc-background-panel.c
+index 9814f88a0..844536b34 100644
+--- a/panels/background/cc-background-panel.c
++++ b/panels/background/cc-background-panel.c
+@@ -167,14 +167,14 @@ get_default_theme(const gchar *theme)
+ static gboolean
+ does_theme_exist(const gchar *theme_name, const gchar *theme_name_suffix)
+ {
+-  gchar *theme_index_file_path;
++  gchar *theme_path;
+   gboolean retval = FALSE;
+ 
+-  theme_index_file_path = g_strconcat ("/usr/share/themes/", theme_name, theme_name_suffix, "/index.theme", NULL);
+-  if (g_access(theme_index_file_path, F_OK) == 0)
++  theme_path = g_strconcat ("/usr/share/themes/", theme_name, theme_name_suffix, NULL);
++  if (g_access(theme_path, F_OK) == 0)
+     retval = TRUE;
+ 
+-  g_free(theme_index_file_path);
++  g_free(theme_path);
+ 
+   return retval;
+ }
+-- 
+2.39.2
+

--- a/debs/gnome-control-center/puavo/patches/0010-puavo-appearance-accept-Dark-and-dark-as-valid-dark-.patch
+++ b/debs/gnome-control-center/puavo/patches/0010-puavo-appearance-accept-Dark-and-dark-as-valid-dark-.patch
@@ -1,0 +1,44 @@
+From 5bd218aeb3a7c16c9a0488fead8942f42779f2cc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Fri, 17 May 2024 18:05:08 +0300
+Subject: [PATCH 10/11] [puavo] appearance: accept "Dark" and "dark" as valid
+ dark suffixes
+
+KvArc => KvArcDark
+---
+ panels/background/cc-background-panel.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/panels/background/cc-background-panel.c b/panels/background/cc-background-panel.c
+index 844536b34..aa3c043ad 100644
+--- a/panels/background/cc-background-panel.c
++++ b/panels/background/cc-background-panel.c
+@@ -80,7 +80,7 @@ struct _CcBackgroundPanel
+   CcIconThemeChooser *icon_theme_chooser;
+ };
+ 
+-static const gchar *const DARK_SUFFIXES[] = {"-Dark", "-dark"};
++static const gchar *const DARK_SUFFIXES[] = {"Dark", "dark", "-Dark", "-dark"};
+ static const int DARK_SUFFIX_COUNT = sizeof(DARK_SUFFIXES) / sizeof(DARK_SUFFIXES[0]);
+ 
+ CC_PANEL_REGISTER (CcBackgroundPanel, cc_background_panel)
+@@ -145,10 +145,12 @@ get_default_theme(const gchar *theme)
+   if (!theme)
+     return NULL;
+ 
+-  /* If the theme is somehow just "-Dark", then it's not considered to
+-   * be Dark version. Because would it be the Dark version of nothing?
+-   * What is Darker than nothing? Nothing. So, "-Dark" cannot be Dark
+-   * version, it's the default version. */
++  /* If the theme name is somehow just the suffix, e.g. "-Dark", then
++   * it's not considered as a Dark version. Because then it would be
++   * the Dark version of nothing. But that does not make any sense.
++   * What is Darker than nothing? Nothing.
++   * So, "-Dark" cannot be Dark version, it's the default
++   * version. */
+   for (int i = 0; i < DARK_SUFFIX_COUNT; ++i)
+     {
+       if (g_strcmp0 (theme, DARK_SUFFIXES[i]) == 0)
+-- 
+2.39.2
+

--- a/debs/gnome-control-center/puavo/patches/0011-puavo-appearance-make-color-scheme-switch-change-als.patch
+++ b/debs/gnome-control-center/puavo/patches/0011-puavo-appearance-make-color-scheme-switch-change-als.patch
@@ -1,0 +1,173 @@
+From d21430fea0c97364b9f3d8d251ae987b78079598 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Fri, 17 May 2024 18:07:17 +0300
+Subject: [PATCH 11/11] [puavo] appearance: make color scheme switch change
+ also Qt Kvantum theme
+
+Note that Qt applications are not updated immediately, they need to be
+restarted to apply the color scheme change.
+
+I wonder if there's a DBus signal which we could emit?
+---
+ panels/background/cc-background-panel.c | 113 +++++++++++++++++++++++-
+ 1 file changed, 112 insertions(+), 1 deletion(-)
+
+diff --git a/panels/background/cc-background-panel.c b/panels/background/cc-background-panel.c
+index aa3c043ad..9aa6fb710 100644
+--- a/panels/background/cc-background-panel.c
++++ b/panels/background/cc-background-panel.c
+@@ -200,9 +200,110 @@ get_next_theme (const gchar         *theme,
+       g_warning("Dark theme does not exist for theme %s\n", theme);
+     }
+ 
++  return g_strdup (default_theme);
++}
+ 
++static GKeyFile*
++load_qt_config_key_file(const gchar *const config_file_path)
++{
++  g_autoptr(GError) error = NULL;
++  GKeyFile *key_file = g_key_file_new();
+ 
+-  return g_strdup (default_theme);
++  if (!g_key_file_load_from_file (key_file, config_file_path, G_KEY_FILE_NONE, &error))
++    {
++      if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
++        g_warning ("Failed to load Qt config file '%s': %s", config_file_path, error->message);
++      g_key_file_free(key_file);
++      return NULL;
++    }
++
++  return key_file;
++}
++
++static gchar*
++read_qt_config_theme(const gchar *const config_file_path)
++{
++  g_autoptr(GKeyFile) key_file = load_qt_config_key_file (config_file_path);
++
++  if (key_file == NULL)
++    return NULL;
++
++  return g_key_file_get_string (key_file, "General", "theme", NULL);
++}
++
++static gchar*
++get_qt_config_file_path(const gchar *const base_dir)
++{
++  return g_strconcat(base_dir, "/Kvantum/kvantum.kvconfig", NULL);
++}
++
++static gchar*
++get_qt_config_file_path_user()
++{
++  return get_qt_config_file_path (g_get_user_config_dir ());
++}
++
++static gchar*
++get_qt_theme_system()
++{
++  const gchar *const *dirs = g_get_system_config_dirs ();
++
++  for (int i = 0; dirs[i] != NULL; ++i)
++    {
++      gchar *config_file_path = get_qt_config_file_path (dirs[i]);
++      gchar *theme = read_qt_config_theme (config_file_path);
++
++      g_free (config_file_path);
++
++      if (theme)
++        return theme;
++    }
++
++  return NULL;
++}
++
++static gchar*
++get_qt_theme_user()
++{
++  g_autofree gchar *config_file_path = get_qt_config_file_path_user ();
++
++  return read_qt_config_theme (config_file_path);
++}
++
++static gchar*
++get_qt_theme ()
++{
++  gchar *theme;
++
++  theme = get_qt_theme_user ();
++  if (theme == NULL)
++    theme = get_qt_theme_system ();
++
++  return theme;
++}
++
++static void
++set_qt_theme (const gchar *theme)
++{
++  g_autoptr(GError) error = NULL;
++  g_autofree gchar *config_file_path = get_qt_config_file_path_user ();
++  g_autofree gchar *config_dir_path = g_path_get_dirname (config_file_path);
++  g_autoptr(GKeyFile) key_file = load_qt_config_key_file (config_file_path);
++
++  if (key_file == NULL)
++    key_file = g_key_file_new ();
++
++  g_key_file_set_string (key_file, "General", "theme", theme);
++
++  if (g_mkdir_with_parents (config_dir_path, 0755) < 0)
++    {
++      g_warning ("Failed to ensure configuration directory '%s' exists: %s",
++                 config_dir_path, g_strerror (errno));
++      return;
++    }
++
++  if (!g_key_file_save_to_file (key_file, config_file_path, &error))
++    g_warning ("Failed to save Qt config file '%s': %s", config_file_path, error->message);
+ }
+ 
+ static void
+@@ -210,8 +311,10 @@ set_color_scheme (CcBackgroundPanel   *self,
+                   GDesktopColorScheme  color_scheme)
+ {
+   g_autofree gchar *current_gtk_theme = NULL;
++  g_autofree gchar *current_qt_theme = NULL;
+   g_autofree gchar *current_shell_theme = NULL;
+   g_autofree gchar *next_gtk_theme = NULL;
++  g_autofree gchar *next_qt_theme = NULL;
+   g_autofree gchar *next_shell_theme = NULL;
+   GDesktopColorScheme scheme;
+ 
+@@ -221,6 +324,9 @@ set_color_scheme (CcBackgroundPanel   *self,
+                                              INTERFACE_GTK_THEME_KEY);
+   next_gtk_theme = get_next_theme(current_gtk_theme, color_scheme);
+ 
++  current_qt_theme = get_qt_theme();
++  next_qt_theme = get_next_theme(current_qt_theme, color_scheme);
++
+   if (self->maybe_user_theme_settings)
+   {
+     current_shell_theme = g_settings_get_string (self->maybe_user_theme_settings,
+@@ -232,6 +338,7 @@ set_color_scheme (CcBackgroundPanel   *self,
+    * screen transition */
+   if (color_scheme == scheme
+       && g_strcmp0(current_gtk_theme, next_gtk_theme) == 0
++      && g_strcmp0(current_qt_theme, next_qt_theme) == 0
+       && (self->maybe_user_theme_settings == NULL || g_strcmp0(current_shell_theme, next_shell_theme) == 0))
+     return;
+ 
+@@ -246,6 +353,10 @@ set_color_scheme (CcBackgroundPanel   *self,
+   else
+     g_warning ("Next GTK theme is not defined, not changing GTK theme");
+ 
++  if (next_qt_theme)
++    set_qt_theme(next_qt_theme);
++  else
++    g_warning ("Next Qt theme is not defined, not changing Qt theme");
+ 
+   if (self->maybe_user_theme_settings)
+     {
+-- 
+2.39.2
+


### PR DESCRIPTION
Three new patches:

1. https://github.com/puavo-org/gnome-control-center/commit/9dd2bef9ed7e14e19d613852e37be7f2e8ba381d
2. https://github.com/puavo-org/gnome-control-center/commit/5bd218aeb3a7c16c9a0488fead8942f42779f2cc
3. https://github.com/puavo-org/gnome-control-center/commit/d21430fea0c97364b9f3d8d251ae987b78079598
