### PR TITLE
devscripts/remove-usb-device: allow removing fixed removables too

### DIFF
--- a/parts/devscripts/bin/remove-usb-device
+++ b/parts/devscripts/bin/remove-usb-device
@@ -39,7 +39,7 @@ def _main():
         with open(
             os.path.join(sysfs_path, "removable"), encoding="ascii"
         ) as removable_file:
-            is_removable = removable_file.read().strip() == "removable"
+            is_removable = removable_file.read().strip() in ("fixed", "removable")
 
         if not is_removable:
             print(


### PR DESCRIPTION
Fixed USB devices can be removed too.

Root HUBs cannot, and their removable state is `unknown`.