### PR TITLE
Fix hplip udev rule issues in install_hp_plugins puppet

### DIFF
--- a/rules/install_hp_plugins/manifests/init.pp
+++ b/rules/install_hp_plugins/manifests/init.pp
@@ -9,6 +9,24 @@ class install_hp_plugins {
   }
 
   file {
+    '/etc/udev/rules.d/40-libsane.rules':
+      mode    => '0644',
+      require => Exec['puavo-download-hp-plugins'];
+    '/etc/udev/rules.d/S99-2000S1.rules':
+      mode    => '0644',
+      require => Exec['puavo-download-hp-plugins'];
+  }
+
+  exec {
+    'fix-hplip-udev-issues':
+      command => 'sed -i "s/libsane_rules_end/libsane_usb_rules_end/g"\
+        /etc/udev/rules.d/40-libsane.rules /etc/udev/rules.d/S99-2000S1.rules',
+      require => Exec['puavo-download-hp-plugins'],
+      onlyif => ['grep -o libsane_rules_end /etc/udev/rules.d/40-libsane.rules \
+        /etc/udev/rules.d/S99-2000S1.rules'];
+  }
+
+  file {
     '/usr/local/sbin/puavo-download-hp-plugins':
       mode    => '0755',
       require => [ Package['expect'], Package['hplip'] ],


### PR DESCRIPTION
As documented on https://bugs.launchpad.net/hplip/+bug/1847477 - the issues somewhy cause too verbose errors especially in bookworm logs.

Should fix at least most of remaining https://github.com/puavo-org/puavo-os/issues/677