### PR TITLE
Add MolView molecular modelling link to puavomenu

### DIFF
--- a/rules/puavomenu/templates/menudata/50-default.json
+++ b/rules/puavomenu/templates/menudata/50-default.json
@@ -1051,6 +1051,19 @@
         "org.mobsya.ThymioSuite": {
             "tags": "default"
         },
+        "org.molview": {
+            "type": "web",
+            "url": "https://molview.org/",
+            "name": {
+                "fi": "MolView-molekyylimallinnus",
+                "en": "MolView molecular modelling",
+                "sv": "MolView - Molekylär modellering",
+                "de": "MolView - Molekulare Modellierung"
+            },
+            "icon": "/usr/share/icons/hicolor/48x48/apps/kalzium.png",
+            "tags": "default, education, science",
+            "keywords": "molview, marvin sketch"
+        },
         "org.openshot.OpenShot": {
             "tags": "default"
         },
@@ -1837,6 +1850,7 @@
                 "avogadro2",
                 "MarvinSketch",
                 "MarvinView",
+                "org.molview",
                 "org.kde.kalzium",
                 "LoggerPro",
                 "LoggerPro3",
@@ -1956,6 +1970,7 @@
                 "org.kde.kalzium",
                 "MarvinSketch",
                 "MarvinView",
+                "org.molview",
                 "mandelbulber2",
                 "org.qgis.qgis",
                 "anki"
@@ -2474,6 +2489,7 @@
                 "makecode",
                 "kahoot",
                 "sanomapro",
+                "org.molview",
                 "otava-oppilas",
                 "otava-opiskelija",
                 "edison",


### PR DESCRIPTION
Due to less-than-fluently working licensing system with some other molecular modelling software shipped in puavo system nowadays, there might be a demand for something that just works out of box. MolView seems to provide a nice and accessible UI, and the typical high school usecases seem to be possible. It has also been noted e.g. in MAOL materials: https://maol.fi/materiaalit/ohjelmistojen-pedagoginen-hyodyntaminen-matematiikassa-fysiikassa-ja-kemiassa/m4arm/ The Terms of Use don't seem to contain anything too critical, either.