### PR TITLE
Clear rdiffs to make space for images in puavo-bootserver-sync-images

### DIFF
--- a/parts/ltsp/bootserver/sbin/puavo-bootserver-sync-images
+++ b/parts/ltsp/bootserver/sbin/puavo-bootserver-sync-images
@@ -329,24 +329,24 @@ class Series
 
     info(4, "Downloading client diffs")
 
-    images.each do |image|
-      image.diffs.each do |diff|
-        # We want only diffs that have been marked are in use.
-        next unless diff.in_use
-
-        if diff.materialize(@series_name) then
-          info(3, "Diff sync OK: #{ diff.statemsg }", HighLine::GREEN)
-          begin
-            torrents.make(diff)
-          rescue StandardError => e
-            warning(3, "Could not make a torrent for #{ diff.filename }: " \
-                         + e.message)
-            all_syncs_ok = false
-          end
-        else
+    # We want only diffs that have been marked are in use.
+    diff_file_queue = images.map{ |m| m.diffs.select{ |d| d.in_use > 0 } }.flatten.uniq
+    # Priorities. Start with the best size / usage ratios as it is possible that we run
+    # out of space during this.
+    diff_file_queue.sort_by!{|d| d.size / d.in_use }
+    diff_file_queue.each do |diff|
+      if diff.materialize(@series_name) then
+        info(3, "Diff sync OK: #{ diff.statemsg }", HighLine::GREEN)
+        begin
+          torrents.make(diff)
+        rescue StandardError => e
+          warning(3, "Could not make a torrent for #{ diff.filename }: " \
+                        + e.message)
           all_syncs_ok = false
-          warning(3, "Diff sync FAILED: #{ diff.statemsg }")
         end
+      else
+        all_syncs_ok = false
+        warning(3, "Diff sync FAILED: #{ diff.statemsg }")
       end
     end
 

--- a/parts/ltsp/bootserver/sbin/puavo-bootserver-sync-images
+++ b/parts/ltsp/bootserver/sbin/puavo-bootserver-sync-images
@@ -139,6 +139,10 @@ class Series
     end
   end
 
+  def all_diffs
+    @by_version.map{ |m| m[1].diffs }.flatten.uniq
+  end
+
   # Query puavo-rest for all devices and check used images.
   # Images and diffs are marked, required images returned.
   def get_images_used_by_puavo_devices(bootserver_data, managed_images)
@@ -310,6 +314,7 @@ class Series
 
     @image_list.each do |image|
       info(4, "Syncing #{ image.id }")
+      image.set_diff_list all_diffs
 
       if image.materialize(@series_name) then
         info(3, "Image sync OK: #{ image.statemsg }", HighLine::GREEN)
@@ -480,7 +485,7 @@ class SyncFileWithMetadata < SyncFile
     @size   = size
     @urls   = urls
 
-    @in_use        = false
+    @in_use        = 0
     @mtime         = nil
     @state         = SyncState.new
     @verified      = false
@@ -600,7 +605,8 @@ class SyncFileWithMetadata < SyncFile
     raise 'unknown download error'
   end
 
-  def ensure_enough_diskspace
+  def free_diskspace
+    diskspace = -1
     directory = File.dirname(final_path)
 
     block_size, bs_status \
@@ -611,16 +617,21 @@ class SyncFileWithMetadata < SyncFile
     unless bs_status.success? && fb_status.success?
       warning(2, "Could not stat directory for #{ final_path }" \
                    + " when checking disk space")
-      return false
+      return -1
     end
 
     begin
       diskspace = Integer(block_size) * Integer(free_blocks)
     rescue StandardError => e
       warning(2, "Could not determine free disk space for #{ final_path }")
-      return false
+      return -1
     end
+    diskspace
+  end
 
+  def ensure_enough_diskspace
+    diskspace = free_diskspace
+    return false if diskspace == -1
     if @size > diskspace then
       warning(2, "Not enough available disk space for #{ final_path }:" \
                    + " needing #{ @size } bytes, #{ diskspace } available")
@@ -631,7 +642,7 @@ class SyncFileWithMetadata < SyncFile
   end
 
   def mark_in_use(series_name, managed_images)
-    @in_use = true
+    @in_use += 1
     managed_images.add_syncfile(series_name, self)
     return self
   end
@@ -737,6 +748,7 @@ class Image < SyncFileWithMetadata
 
     @id = id
     @version = version
+    @diff_list = []
 
     @diffs_from_by_version = Hash.new
   end
@@ -765,6 +777,38 @@ class Image < SyncFileWithMetadata
   def get_newest_diffs(limit=0)
     @diffs_from_by_version.sort.map { |version, diff| diff } \
                           .reverse.slice(0, limit).reverse
+  end
+
+  def set_diff_list list
+    @diff_list = list
+  end
+
+  def ensure_enough_diskspace
+    res = super
+    if !res
+      info(3, "Not enough space for #{self.id}, trying to clean up less important rdiffs")
+
+      # Magical AI priorization of the diff files
+      @diff_list.select!{|d| d.inplace?}.sort_by!{|d| d.in_use == 0 ? -99999999999 : -d.size / d.in_use }
+      if @size > @diff_list.map(&:size).reduce(&:+) + free_diskspace
+        info(3, "Deleting all wouldn't free enough (only #{@diff_list.map(&:size).reduce(&:+)}), so not even trying")
+        return false
+      end
+      @diff_list.each do |d|
+        str = "Trying to delete #{d.filename} (size #{d.size}, used by #{d.in_use})"
+        if !d.delete
+          info(2, str + "... Didn't work. Trying next one.")
+        elsif res = super
+          info(2, str)
+          info(3, "Good, got enough space now. Continuing.")
+          break
+        else
+          info(2, str + "... Still not enough space. Trying to delete next one.")
+        end
+      end
+      info(3, "All possible rdiffs deleted but still not enough space.") if !res
+    end
+    res
   end
 
   # Create the current image from an old image by using a patch.  First

--- a/parts/ltsp/bootserver/sbin/puavo-bootserver-sync-images
+++ b/parts/ltsp/bootserver/sbin/puavo-bootserver-sync-images
@@ -92,6 +92,7 @@ def warning(level, msg)
   log(level, STDERR, Syslog::LOG_WARNING, "WARNING: #{ msg }", HighLine::RED)
 end
 
+
 class Series
   attr_reader :series_name
 
@@ -137,10 +138,6 @@ class Series
       diff = Diff.new(cksum, baseimage, targetimage, filename, sha256, size, urls)
       targetimage.add_diff(diff)
     end
-  end
-
-  def all_diffs
-    @by_version.map{ |m| m[1].diffs }.flatten.uniq
   end
 
   # Query puavo-rest for all devices and check used images.
@@ -314,7 +311,6 @@ class Series
 
     @image_list.each do |image|
       info(4, "Syncing #{ image.id }")
-      image.set_diff_list all_diffs
 
       if image.materialize(@series_name) then
         info(3, "Image sync OK: #{ image.statemsg }", HighLine::GREEN)
@@ -330,11 +326,17 @@ class Series
     info(4, "Downloading client diffs")
 
     # We want only diffs that have been marked are in use.
-    diff_file_queue = images.map{ |m| m.diffs.select{ |d| d.in_use > 0 } }.flatten.uniq
-    # Priorities. Start with the best size / usage ratios as it is possible that we run
-    # out of space during this.
-    diff_file_queue.sort_by!{|d| d.size / d.in_use }
-    diff_file_queue.each do |diff|
+    diff_file_queue = images.map do |image|
+                        image.diffs.select { |diff| diff.in_use > 0 }
+                      end.flatten.uniq
+
+    # Prioritize downloads, start with the best size / usage ratios
+    # as it is possible that we run out of space during this.  Smaller
+    # number means higher priority.
+    prioritized_diff_file_queue \
+      = diff_file_queue.sort_by { |diff| diff.size / diff.in_use }
+
+    prioritized_diff_file_queue.each do |diff|
       if diff.materialize(@series_name) then
         info(3, "Diff sync OK: #{ diff.statemsg }", HighLine::GREEN)
         begin
@@ -356,6 +358,52 @@ class Series
     end
 
     return all_syncs_ok
+  end
+
+  def remove_diffs_to_free_diskspace(syncfile)
+    diffs_in_series = @by_id.values.map { |image| image.diffs }.flatten.uniq
+    diffs_in_series_cunsuming_diskspace \
+      = diffs_in_series.select { |d| d.inplace? }
+
+    current_free_diskspace = syncfile.lookup_free_diskspace()
+    return false unless current_free_diskspace
+
+    space_currently_taken_by_diffs \
+      = diffs_in_series_cunsuming_diskspace.map(&:size).sum
+
+    space_potentially_available \
+      = space_currently_taken_by_diffs + current_free_diskspace
+    if syncfile.size > space_potentially_available then
+      info(3, 'Deleting diffs would not free enough' \
+                + " (only #{ space_currently_taken_by_diffs } bytes)" \
+                + ' so not even trying')
+      return false
+    end
+
+    # Magical AI priorization of the diff files.  Files with the biggest
+    # priority number are to be deleted first.
+    diffs_sorted_by_priority \
+      = diffs_in_series_cunsuming_diskspace.select { |d| d.inplace? } \
+         .sort_by { |d| d.in_use == 0 ? 999999999999 : d.size / d.in_use } \
+         .reverse
+
+    diffs_sorted_by_priority.each do |d|
+      logmsg = "Deleting #{ d.filename } (size=#{ d.size } users=#{ d.in_use })"
+      unless d.delete() then
+        warning(2, "#{ logmsg } ... FAILED.")
+        next
+      end
+      info(2, "#{ logmsg } ... OK.")
+
+      enough, diskspace = syncfile.check_diskspace()
+      if enough then
+        info(3, 'Got enough space now, continuing')
+        return true
+      end
+    end
+
+    info(3, 'All possible rdiffs deleted but still not enough space')
+    return false
   end
 
   def cleanup_tempfiles
@@ -456,6 +504,31 @@ class SyncFile
     end
 
     return all_deleted_ok
+  end
+
+  def lookup_free_diskspace
+    diskspace = nil
+    directory = File.dirname(final_path)
+
+    block_size, bs_status \
+      = Open3.capture2("stat", "--file-system", "--format", "%S", directory)
+    free_blocks, fb_status \
+      = Open3.capture2("stat", "--file-system", "--format", "%a", directory)
+
+    unless bs_status.success? && fb_status.success?
+      warning(2, "Could not stat directory for #{ directory }" \
+                   + " when checking disk space")
+      return nil
+    end
+
+    begin
+      diskspace = Integer(block_size) * Integer(free_blocks)
+    rescue StandardError => e
+      warning(2, "Could not determine free disk space in #{ directory }")
+      return nil
+    end
+
+    return diskspace
   end
 
   def cleanup_tempfiles
@@ -605,40 +678,19 @@ class SyncFileWithMetadata < SyncFile
     raise 'unknown download error'
   end
 
-  def free_diskspace
-    diskspace = -1
-    directory = File.dirname(final_path)
-
-    block_size, bs_status \
-      = Open3.capture2("stat", "--file-system", "--format", "%S", directory)
-    free_blocks, fb_status \
-      = Open3.capture2("stat", "--file-system", "--format", "%a", directory)
-
-    unless bs_status.success? && fb_status.success?
-      warning(2, "Could not stat directory for #{ final_path }" \
-                   + " when checking disk space")
-      return -1
-    end
-
-    begin
-      diskspace = Integer(block_size) * Integer(free_blocks)
-    rescue StandardError => e
-      warning(2, "Could not determine free disk space for #{ final_path }")
-      return -1
-    end
-    diskspace
+  def check_diskspace
+    diskspace = lookup_free_diskspace()
+    return false unless diskspace
+    return [ @size <= diskspace, diskspace ]
   end
 
   def ensure_enough_diskspace
-    diskspace = free_diskspace
-    return false if diskspace == -1
-    if @size > diskspace then
-      warning(2, "Not enough available disk space for #{ final_path }:" \
-                   + " needing #{ @size } bytes, #{ diskspace } available")
-      return false
-    end
+    enough, diskspace = check_diskspace()
+    return true if enough
 
-    return true
+    warning(2, "Not enough available disk space for #{ final_path }:" \
+                 + " needing #{ @size } bytes, #{ diskspace } available")
+    return false
   end
 
   def mark_in_use(series_name, managed_images)
@@ -738,7 +790,7 @@ end
 class Image < SyncFileWithMetadata
   attr_reader :id, :version
 
-  def initialize(cksum, filename, id, sha256, size, urls, version)
+  def initialize(cksum, filename, id, sha256, size, urls, version, series)
     super(cksum, filename, sha256, size, urls)
 
     raise 'id is not set' \
@@ -747,8 +799,8 @@ class Image < SyncFileWithMetadata
       unless version && version.kind_of?(String) && !version.empty?
 
     @id = id
+    @series = series
     @version = version
-    @diff_list = []
 
     @diffs_from_by_version = Hash.new
   end
@@ -779,36 +831,12 @@ class Image < SyncFileWithMetadata
                           .reverse.slice(0, limit).reverse
   end
 
-  def set_diff_list list
-    @diff_list = list
-  end
-
   def ensure_enough_diskspace
-    res = super
-    if !res
-      info(3, "Not enough space for #{self.id}, trying to clean up less important rdiffs")
+    have_enough = super()
+    return true if have_enough
 
-      # Magical AI priorization of the diff files
-      @diff_list.select!{|d| d.inplace?}.sort_by!{|d| d.in_use == 0 ? -99999999999 : -d.size / d.in_use }
-      if @size > @diff_list.map(&:size).reduce(&:+) + free_diskspace
-        info(3, "Deleting all wouldn't free enough (only #{@diff_list.map(&:size).reduce(&:+)}), so not even trying")
-        return false
-      end
-      @diff_list.each do |d|
-        str = "Trying to delete #{d.filename} (size #{d.size}, used by #{d.in_use})"
-        if !d.delete
-          info(2, str + "... Didn't work. Trying next one.")
-        elsif res = super
-          info(2, str)
-          info(3, "Good, got enough space now. Continuing.")
-          break
-        else
-          info(2, str + "... Still not enough space. Trying to delete next one.")
-        end
-      end
-      info(3, "All possible rdiffs deleted but still not enough space.") if !res
-    end
-    res
+    info(3, "Not enough space for #{ self.id }, cleaning up unimportant rdiffs")
+    return @series.remove_diffs_to_free_diskspace(self)
   end
 
   # Create the current image from an old image by using a patch.  First
@@ -1317,7 +1345,8 @@ module SeriesControl
                           imagedata["sha256"],
                           imagedata["size"],
                           imagedata["urls"],
-                          imagedata["version"])
+                          imagedata["version"],
+                          series)
         series.add_image(image)
       end
 


### PR DESCRIPTION
Reads the data on all rdiffs in the image series and priorizes them based on size and user count; removes them starting from least important until the image fits.

Fixes (probably, TBC) #555 