### PR TITLE
debs/gnome-control-center: fix theme switching to default

### DIFF
--- a/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
+++ b/debs/gnome-control-center/puavo/patches/0001-puavo-Disable-user-accounts.patch
@@ -1,7 +1,7 @@
 From 2c4fcacd8ba6076f985f88b4587f123f10a8ceb5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 11:01:01 +0300
-Subject: [PATCH 01/11] [puavo] Disable user-accounts
+Subject: [PATCH 01/14] [puavo] Disable user-accounts
 
 ---
  shell/cc-panel-loader.c | 1 -

--- a/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
+++ b/debs/gnome-control-center/puavo/patches/0002-puavo-appearance-make-style-switch-change-themes-too.patch
@@ -1,7 +1,7 @@
 From 660bd4117b227d9f6a6e95410fff3ea5824e94b2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Sun, 21 Apr 2024 21:09:46 +0300
-Subject: [PATCH 02/11] [puavo] appearance: make style switch change themes too
+Subject: [PATCH 02/14] [puavo] appearance: make style switch change themes too
 
 ---
  panels/background/cc-background-panel.c | 101 +++++++++++++++++++++++-

--- a/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
+++ b/debs/gnome-control-center/puavo/patches/0003-puavo-appearance-accept-dark-as-a-valid-dark-theme-p.patch
@@ -1,7 +1,7 @@
 From 647cd9487b42d9dc5d7e7e353ae2c0a1d0cc9bc0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 26 Apr 2024 14:18:07 +0300
-Subject: [PATCH 03/11] [puavo] appearance: accept -dark as a valid dark theme
+Subject: [PATCH 03/14] [puavo] appearance: accept -dark as a valid dark theme
  prefix
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
+++ b/debs/gnome-control-center/puavo/patches/0004-puavo-appearance-add-icon-theme-chooser.patch
@@ -1,7 +1,7 @@
 From ca4a082e52b5e5ae053d937486fdb0f42801e6f6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Sun, 28 Apr 2024 21:43:21 +0300
-Subject: [PATCH 04/11] [puavo] appearance: add icon theme chooser
+Subject: [PATCH 04/14] [puavo] appearance: add icon theme chooser
 
 ---
  panels/background/background.gresource.xml    |   2 +

--- a/debs/gnome-control-center/puavo/patches/0005-puavo-Update-translations-fi-sv-de.patch
+++ b/debs/gnome-control-center/puavo/patches/0005-puavo-Update-translations-fi-sv-de.patch
@@ -1,7 +1,7 @@
 From fd2d1c5dddd2994d4e3071a24aecf1e60d098b0e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Mon, 29 Apr 2024 18:42:03 +0300
-Subject: [PATCH 05/11] [puavo] Update translations fi, sv, de
+Subject: [PATCH 05/14] [puavo] Update translations fi, sv, de
 
 ---
  po/de.po | 6 +++++-

--- a/debs/gnome-control-center/puavo/patches/0006-puavo-appearance-tighten-icon-chooser-layout-to-fit-.patch
+++ b/debs/gnome-control-center/puavo/patches/0006-puavo-appearance-tighten-icon-chooser-layout-to-fit-.patch
@@ -1,7 +1,7 @@
 From 1d6951c9a938cbf18ef525b52bf030f8be8c924a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Mon, 29 Apr 2024 19:15:57 +0300
-Subject: [PATCH 06/11] [puavo] appearance: tighten icon chooser layout to fit
+Subject: [PATCH 06/14] [puavo] appearance: tighten icon chooser layout to fit
  all 5 icon themes on the same row
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0007-puavo-appearance-add-icon-theme-labels.patch
+++ b/debs/gnome-control-center/puavo/patches/0007-puavo-appearance-add-icon-theme-labels.patch
@@ -1,7 +1,7 @@
 From d5d48282a3ffa3faee0059a0668ff35743bb8098 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Mon, 29 Apr 2024 19:16:44 +0300
-Subject: [PATCH 07/11] [puavo] appearance: add icon theme labels
+Subject: [PATCH 07/14] [puavo] appearance: add icon theme labels
 
 ---
  panels/background/cc-icon-theme-chooser.c | 15 ++++++++++++++-

--- a/debs/gnome-control-center/puavo/patches/0008-puavo-appearance-set-Shell-theme-and-GTK-theme-indep.patch
+++ b/debs/gnome-control-center/puavo/patches/0008-puavo-appearance-set-Shell-theme-and-GTK-theme-indep.patch
@@ -1,7 +1,7 @@
 From 89f920ff8041d09050dcdb65262f2b3c6f994d1c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Wed, 15 May 2024 23:07:40 +0300
-Subject: [PATCH 08/11] [puavo] appearance: set Shell theme and GTK theme
+Subject: [PATCH 08/14] [puavo] appearance: set Shell theme and GTK theme
  independently
 
 ---

--- a/debs/gnome-control-center/puavo/patches/0009-puavo-appearance-change-theme-existence-check-to-tes.patch
+++ b/debs/gnome-control-center/puavo/patches/0009-puavo-appearance-change-theme-existence-check-to-tes.patch
@@ -1,7 +1,7 @@
 From 9dd2bef9ed7e14e19d613852e37be7f2e8ba381d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 17 May 2024 18:04:39 +0300
-Subject: [PATCH 09/11] [puavo] appearance: change theme existence check to
+Subject: [PATCH 09/14] [puavo] appearance: change theme existence check to
  test only the existence of theme dir
 
 Not all themes have index.theme files, e.g KvArc.

--- a/debs/gnome-control-center/puavo/patches/0010-puavo-appearance-accept-Dark-and-dark-as-valid-dark-.patch
+++ b/debs/gnome-control-center/puavo/patches/0010-puavo-appearance-accept-Dark-and-dark-as-valid-dark-.patch
@@ -1,7 +1,7 @@
 From 5bd218aeb3a7c16c9a0488fead8942f42779f2cc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 17 May 2024 18:05:08 +0300
-Subject: [PATCH 10/11] [puavo] appearance: accept "Dark" and "dark" as valid
+Subject: [PATCH 10/14] [puavo] appearance: accept "Dark" and "dark" as valid
  dark suffixes
 
 KvArc => KvArcDark

--- a/debs/gnome-control-center/puavo/patches/0011-puavo-appearance-make-color-scheme-switch-change-als.patch
+++ b/debs/gnome-control-center/puavo/patches/0011-puavo-appearance-make-color-scheme-switch-change-als.patch
@@ -1,7 +1,7 @@
 From d21430fea0c97364b9f3d8d251ae987b78079598 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
 Date: Fri, 17 May 2024 18:07:17 +0300
-Subject: [PATCH 11/11] [puavo] appearance: make color scheme switch change
+Subject: [PATCH 11/14] [puavo] appearance: make color scheme switch change
  also Qt Kvantum theme
 
 Note that Qt applications are not updated immediately, they need to be

--- a/debs/gnome-control-center/puavo/patches/0012-Create-private-network-if-no-system-permission-in-gn.patch
+++ b/debs/gnome-control-center/puavo/patches/0012-Create-private-network-if-no-system-permission-in-gn.patch
@@ -1,7 +1,8 @@
-From 71f21f6236116ea3bb93e2fb843cc5027eb33736 Mon Sep 17 00:00:00 2001
+From 42b24a4e4ffe7bd8c81a22bb579aa1be307a2844 Mon Sep 17 00:00:00 2001
 From: Tuomas Nurmi <tuomas.nurmi@opinsys.fi>
 Date: Fri, 31 May 2024 16:43:35 +0300
-Subject: [PATCH] Create private network if no system permission in gnome-control-center
+Subject: [PATCH 12/14] Create private network if no system permission in
+ gnome-control-center
 
 ---
  panels/network/network-dialogs.c | 15 +++++++++++++++
@@ -34,5 +35,5 @@ index 83df99a72..05a0c2c71 100644
  		                                             connection,
  		                                             device,
 -- 
-2.30.2
+2.39.2
 

--- a/debs/gnome-control-center/puavo/patches/0013-puavo-appearance-fix-dark-suffix-strip-order.patch
+++ b/debs/gnome-control-center/puavo/patches/0013-puavo-appearance-fix-dark-suffix-strip-order.patch
@@ -1,0 +1,32 @@
+From 294f26f451ac258cb808c01807ec53e20c879f50 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Tue, 20 Aug 2024 19:28:32 +0300
+Subject: [PATCH 13/14] [puavo] appearance: fix dark suffix strip order
+
+New order ensures longest possible suffix gets stripped, e.g. dash is
+not left hanging around.
+
+Example:
+
+Before: Yaru-dark -> Yaru-
+After: Yaru-dark -> Yaru
+---
+ panels/background/cc-background-panel.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/panels/background/cc-background-panel.c b/panels/background/cc-background-panel.c
+index 9aa6fb710..e1ca58481 100644
+--- a/panels/background/cc-background-panel.c
++++ b/panels/background/cc-background-panel.c
+@@ -80,7 +80,7 @@ struct _CcBackgroundPanel
+   CcIconThemeChooser *icon_theme_chooser;
+ };
+ 
+-static const gchar *const DARK_SUFFIXES[] = {"Dark", "dark", "-Dark", "-dark"};
++static const gchar *const DARK_SUFFIXES[] = {"-Dark", "-dark", "Dark", "dark"};
+ static const int DARK_SUFFIX_COUNT = sizeof(DARK_SUFFIXES) / sizeof(DARK_SUFFIXES[0]);
+ 
+ CC_PANEL_REGISTER (CcBackgroundPanel, cc_background_panel)
+-- 
+2.39.2
+

--- a/debs/gnome-control-center/puavo/patches/0014-puavo-appearance-strip-trailing-dash-from-existing-t.patch
+++ b/debs/gnome-control-center/puavo/patches/0014-puavo-appearance-strip-trailing-dash-from-existing-t.patch
@@ -1,0 +1,45 @@
+From b40586ac0a2f51afdd18be1428fe7d03d81e9bee Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tuomas=20R=C3=A4s=C3=A4nen?= <tuomas.rasanen@opinsys.fi>
+Date: Tue, 20 Aug 2024 19:33:01 +0300
+Subject: [PATCH 14/14] [puavo] appearance: strip trailing dash from existing
+ themes
+
+This fixes existing invalid theme names when Appearance panel is
+loaded/activated.
+---
+ panels/background/cc-background-panel.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/panels/background/cc-background-panel.c b/panels/background/cc-background-panel.c
+index e1ca58481..86ba48f51 100644
+--- a/panels/background/cc-background-panel.c
++++ b/panels/background/cc-background-panel.c
+@@ -185,7 +185,15 @@ static gchar*
+ get_next_theme (const gchar         *theme,
+                 GDesktopColorScheme color_scheme)
+ {
+-  g_autofree gchar *default_theme = get_default_theme (theme);
++  g_autofree gchar *fixed_theme = NULL;
++  g_autofree gchar *default_theme = NULL;
++
++  if (g_str_has_suffix (theme, "-"))
++    fixed_theme = g_strndup(theme, strlen (theme) - 1);
++  else
++    fixed_theme = g_strdup(theme);
++
++  default_theme = get_default_theme (fixed_theme);
+ 
+   if (!default_theme)
+       return NULL;
+@@ -197,7 +205,7 @@ get_next_theme (const gchar         *theme,
+           if (does_theme_exist(default_theme, DARK_SUFFIXES[i]))
+             return g_strconcat (default_theme, DARK_SUFFIXES[i], NULL);
+         }
+-      g_warning("Dark theme does not exist for theme %s\n", theme);
++      g_warning("Dark theme does not exist for theme %s\n", fixed_theme);
+     }
+ 
+   return g_strdup (default_theme);
+-- 
+2.39.2
+


### PR DESCRIPTION
Two new patches, maintained here:

1.  https://github.com/puavo-org/gnome-control-center/commit/294f26f451ac258cb808c01807ec53e20c879f50
 2.  https://github.com/puavo-org/gnome-control-center/commit/b40586ac0a2f51afdd18be1428fe7d03d81e9bee
