### PR TITLE
Add option to defuse Windows EFI boot when Windows is disabled

### DIFF
--- a/parts/core/puavo-conf/scripts/setup_grub_environment
+++ b/parts/core/puavo-conf/scripts/setup_grub_environment
@@ -75,11 +75,11 @@ setup_timeout() {
 
 setup_windows_enabled() {
   if [ "$(puavo-conf puavo.grub.windows.enabled)" = 'true' ]; then
-    puavo-manage-efi enable-windows || return 1
+    puavo-manage-efi --no-efi-is-ok enable-windows || return 1
     grubedit set "puavo_grub_windows_enabled=true" || return 1
   else
     grubedit unset puavo_grub_windows_enabled || return 1
-    puavo-manage-efi disable-windows || return 1
+    puavo-manage-efi --no-efi-is-ok disable-windows || return 1
   fi
 
   return 0

--- a/parts/core/puavo-conf/scripts/setup_grub_environment
+++ b/parts/core/puavo-conf/scripts/setup_grub_environment
@@ -130,7 +130,12 @@ efi_fix_windows() {
 
   if [ -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
     echo 'Repriming Windows...' >&2
+    if [ -e  "${efi_mount_path}/EFI/Microsoft" ]; then
+      echo "Failed to reprime Windows: '${efi_mount_path}/EFI/Microsoft' already exists" >&2
+      return 1
+    fi
     tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
+      rm -rf "${efi_mount_path}/EFI/Microsoft" || true
       umount "${efi_mount_path}" || return 1
       rm -rf "${efi_mount_path}"
       return 1

--- a/parts/core/puavo-conf/scripts/setup_grub_environment
+++ b/parts/core/puavo-conf/scripts/setup_grub_environment
@@ -73,41 +73,100 @@ setup_timeout() {
   fi
 }
 
-efibootmgr_set_windows() {
-  boot_entry_state=$1
+has_efi() {
+  grep -q '^efivarfs ' /proc/mounts
+}
+
+efibootmgr_windows() {
+  efibootmgr_flag=$1
   shift
 
-  case "${boot_entry_state}" in
-    active)
-      efibootmgr_a_flag='-a'
-      ;;
-    inactive)
-      efibootmgr_a_flag='-A'
-      ;;
-    *)
-      echo "Invalid argument (${boot_entry_state}), expected 'active' or 'inactive'" >&2
-      return 1
-      ;;
-  esac
-
   for boot_entry in $(efibootmgr | awk '/Windows/ {print substr($0,5,4)}'); do
-    efibootmgr -q ${efibootmgr_a_flag} -b "${boot_entry}" || return 1
+    efibootmgr -q "${efibootmgr_flag}" -b "${boot_entry}" || return 1
   done
 
   return 0
 }
 
-setup_windows_enabled() {
-  if [ "$(puavo-conf puavo.grub.windows.enabled)" = 'true' ]; then
-    grubedit set "puavo_grub_windows_enabled=true" || return 1
-    efi_boot_state_windows=active
-  else
-    grubedit unset puavo_grub_windows_enabled || return 1
-    efi_boot_state_windows=inactive
+mount_efi_system_partition() {
+  efi_system_partition_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}')
+
+  efi_system_partition_mountpath=$(mktemp -d -p / EFI_SYSTEM_PARTITION.XXXXXXXXXXXX)
+  mount -onodev,nosuid "${efi_system_partition_devpath}" "${efi_system_partition_mountpath}" || {
+    rm -rf "${efi_system_partition_mountpath}"
+    return 1
+  }
+
+  echo "${efi_system_partition_mountpath}"
+}
+
+efi_break_windows() {
+  efi_mount_path=$(mount_efi_system_partition) || return 1
+
+  if [ -d "${efi_mount_path}/EFI/Microsoft" ]; then
+    tar -C "${efi_mount_path}/EFI" -z -c -f "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" Microsoft || {
+      rm -rf "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" || true
+      umount "${efi_mount_path}" || return 1
+      rm -rf "${efi_mount_path}"
+      return 1
+    }
+    rm -rf "${efi_mount_path}/EFI/Microsoft" || {
+      umount "${efi_mount_path}" || return 1
+      rm -rf "${efi_mount_path}"
+      return 1
+    }
   fi
 
-  if grep -q '^efivarfs ' /proc/mounts; then
-      efibootmgr_set_windows "${efi_boot_state_windows}" || return 1
+  umount "${efi_mount_path}" || return 1
+  rm -rf "${efi_mount_path}"
+}
+
+efi_fix_windows() {
+  efi_mount_path=$(mount_efi_system_partition) || return 1
+
+  if [ -f "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" ]; then
+    tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" || {
+      umount "${efi_mount_path}" || return 1
+      rm -rf "${efi_mount_path}"
+      return 1
+    }
+    rm -f "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" || {
+      umount "${efi_mount_path}" || return 1
+      rm -rf "${efi_mount_path}"
+      return 1
+    }
+  fi
+
+  umount "${efi_mount_path}" || return 1
+  rm -rf "${efi_mount_path}"
+}
+
+efi_disable_windows() {
+  if [ "$(puavo-conf puavo.grub.windows.defuse_efi_boot_when_disabled)" != 'true' ]; then
+    echo "puavo.grub.windows.defuse_efi_boot_when_disabled is not true, not disabling Windows EFI boot" >&2
+    return 0
+  fi
+
+  efibootmgr_windows -A || return 1
+  efi_break_windows
+}
+
+efi_enable_windows() {
+  efi_fix_windows || return 1
+  efibootmgr_windows -a
+}
+
+setup_windows_enabled() {
+  if [ "$(puavo-conf puavo.grub.windows.enabled)" = 'true' ]; then
+    if has_efi; then
+      efi_enable_windows || return 1
+    fi
+    grubedit set "puavo_grub_windows_enabled=true" || return 1
+  else
+    grubedit unset puavo_grub_windows_enabled || return 1
+    if has_efi; then
+      efi_disable_windows || return 1
+    fi
   fi
 
   return 0

--- a/parts/core/puavo-conf/scripts/setup_grub_environment
+++ b/parts/core/puavo-conf/scripts/setup_grub_environment
@@ -104,14 +104,14 @@ efi_break_windows() {
   efi_mount_path=$(mount_efi_system_partition) || return 1
 
   if [ -d "${efi_mount_path}/EFI/Microsoft" ]; then
-    defused_windows_tmpfile=$(mktemp -p "${efi_mount_path}/EFI" 'Puavo-defused-Microsoft.tar.gz.tmp.XXXXXXXX')
+    defused_windows_tmpfile=$(mktemp -p "${efi_mount_path}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
     tar -C "${efi_mount_path}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
       rm -rf "${defused_windows_tmpfile}" || true
       umount "${efi_mount_path}" || return 1
       rm -rf "${efi_mount_path}"
       return 1
     }
-    mv "${defused_windows_tmpfile}" "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz"
+    mv "${defused_windows_tmpfile}" "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz"
     rm -rf "${efi_mount_path}/EFI/Microsoft" || {
       umount "${efi_mount_path}" || return 1
       rm -rf "${efi_mount_path}"
@@ -126,13 +126,13 @@ efi_break_windows() {
 efi_fix_windows() {
   efi_mount_path=$(mount_efi_system_partition) || return 1
 
-  if [ -f "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" ]; then
-    tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" || {
+  if [ -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
+    tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
       umount "${efi_mount_path}" || return 1
       rm -rf "${efi_mount_path}"
       return 1
     }
-    rm -f "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" || {
+    rm -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
       umount "${efi_mount_path}" || return 1
       rm -rf "${efi_mount_path}"
       return 1

--- a/parts/core/puavo-conf/scripts/setup_grub_environment
+++ b/parts/core/puavo-conf/scripts/setup_grub_environment
@@ -104,6 +104,7 @@ efi_break_windows() {
   efi_mount_path=$(mount_efi_system_partition) || return 1
 
   if [ -d "${efi_mount_path}/EFI/Microsoft" ]; then
+    echo 'Defusing Windows...' >&2
     defused_windows_tmpfile=$(mktemp -p "${efi_mount_path}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
     tar -C "${efi_mount_path}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
       rm -rf "${defused_windows_tmpfile}" || true
@@ -117,6 +118,7 @@ efi_break_windows() {
       rm -rf "${efi_mount_path}"
       return 1
     }
+    echo 'Windows defused.' >&2
   fi
 
   umount "${efi_mount_path}" || return 1
@@ -127,6 +129,7 @@ efi_fix_windows() {
   efi_mount_path=$(mount_efi_system_partition) || return 1
 
   if [ -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
+    echo 'Repriming Windows...' >&2
     tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
       umount "${efi_mount_path}" || return 1
       rm -rf "${efi_mount_path}"
@@ -137,6 +140,7 @@ efi_fix_windows() {
       rm -rf "${efi_mount_path}"
       return 1
     }
+    echo 'Windows reprimed.' >&2
   fi
 
   umount "${efi_mount_path}" || return 1

--- a/parts/core/puavo-conf/scripts/setup_grub_environment
+++ b/parts/core/puavo-conf/scripts/setup_grub_environment
@@ -105,6 +105,11 @@ efi_break_windows() {
 
   if [ -d "${efi_mount_path}/EFI/Microsoft" ]; then
     echo 'Defusing Windows...' >&2
+    if [ -e "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
+      echo "Failed to defuse Windows, '${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz' already exists" >&2
+      return 1
+    fi
+
     defused_windows_tmpfile=$(mktemp -p "${efi_mount_path}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
     tar -C "${efi_mount_path}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
       rm -rf "${defused_windows_tmpfile}" || true

--- a/parts/core/puavo-conf/scripts/setup_grub_environment
+++ b/parts/core/puavo-conf/scripts/setup_grub_environment
@@ -73,116 +73,13 @@ setup_timeout() {
   fi
 }
 
-has_efi() {
-  grep -q '^efivarfs ' /proc/mounts
-}
-
-efibootmgr_windows() {
-  efibootmgr_flag=$1
-  shift
-
-  for boot_entry in $(efibootmgr | awk '/Windows/ {print substr($0,5,4)}'); do
-    efibootmgr -q "${efibootmgr_flag}" -b "${boot_entry}" || return 1
-  done
-
-  return 0
-}
-
-mount_efi_system_partition() {
-  efi_system_partition_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}')
-
-  efi_system_partition_mountpath=$(mktemp -d -p / EFI_SYSTEM_PARTITION.XXXXXXXXXXXX)
-  mount -onodev,nosuid "${efi_system_partition_devpath}" "${efi_system_partition_mountpath}" || {
-    rm -rf "${efi_system_partition_mountpath}"
-    return 1
-  }
-
-  echo "${efi_system_partition_mountpath}"
-}
-
-efi_break_windows() {
-  efi_mount_path=$(mount_efi_system_partition) || return 1
-
-  if [ -d "${efi_mount_path}/EFI/Microsoft" ]; then
-    echo 'Defusing Windows...' >&2
-    if [ -e "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-      echo "Failed to defuse Windows, '${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz' already exists" >&2
-      return 1
-    fi
-
-    defused_windows_tmpfile=$(mktemp -p "${efi_mount_path}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
-    tar -C "${efi_mount_path}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
-      rm -rf "${defused_windows_tmpfile}" || true
-      umount "${efi_mount_path}" || return 1
-      rm -rf "${efi_mount_path}"
-      return 1
-    }
-    mv "${defused_windows_tmpfile}" "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz"
-    rm -rf "${efi_mount_path}/EFI/Microsoft" || {
-      umount "${efi_mount_path}" || return 1
-      rm -rf "${efi_mount_path}"
-      return 1
-    }
-    echo 'Windows defused.' >&2
-  fi
-
-  umount "${efi_mount_path}" || return 1
-  rm -rf "${efi_mount_path}"
-}
-
-efi_fix_windows() {
-  efi_mount_path=$(mount_efi_system_partition) || return 1
-
-  if [ -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-    echo 'Repriming Windows...' >&2
-    if [ -e  "${efi_mount_path}/EFI/Microsoft" ]; then
-      echo "Failed to reprime Windows: '${efi_mount_path}/EFI/Microsoft' already exists" >&2
-      return 1
-    fi
-    tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
-      rm -rf "${efi_mount_path}/EFI/Microsoft" || true
-      umount "${efi_mount_path}" || return 1
-      rm -rf "${efi_mount_path}"
-      return 1
-    }
-    rm -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
-      umount "${efi_mount_path}" || return 1
-      rm -rf "${efi_mount_path}"
-      return 1
-    }
-    echo 'Windows reprimed.' >&2
-  fi
-
-  umount "${efi_mount_path}" || return 1
-  rm -rf "${efi_mount_path}"
-}
-
-efi_disable_windows() {
-  if [ "$(puavo-conf puavo.grub.windows.defuse_efi_boot_when_disabled)" != 'true' ]; then
-    echo "puavo.grub.windows.defuse_efi_boot_when_disabled is not true, not disabling Windows EFI boot" >&2
-    return 0
-  fi
-
-  efibootmgr_windows -A || return 1
-  efi_break_windows
-}
-
-efi_enable_windows() {
-  efi_fix_windows || return 1
-  efibootmgr_windows -a
-}
-
 setup_windows_enabled() {
   if [ "$(puavo-conf puavo.grub.windows.enabled)" = 'true' ]; then
-    if has_efi; then
-      efi_enable_windows || return 1
-    fi
+    puavo-manage-efi enable-windows || return 1
     grubedit set "puavo_grub_windows_enabled=true" || return 1
   else
     grubedit unset puavo_grub_windows_enabled || return 1
-    if has_efi; then
-      efi_disable_windows || return 1
-    fi
+    puavo-manage-efi disable-windows || return 1
   fi
 
   return 0

--- a/parts/core/puavo-conf/scripts/setup_grub_environment
+++ b/parts/core/puavo-conf/scripts/setup_grub_environment
@@ -73,12 +73,44 @@ setup_timeout() {
   fi
 }
 
+efibootmgr_set_windows() {
+  boot_entry_state=$1
+  shift
+
+  case "${boot_entry_state}" in
+    active)
+      efibootmgr_a_flag='-a'
+      ;;
+    inactive)
+      efibootmgr_a_flag='-A'
+      ;;
+    *)
+      echo "Invalid argument (${boot_entry_state}), expected 'active' or 'inactive'" >&2
+      return 1
+      ;;
+  esac
+
+  for boot_entry in $(efibootmgr | awk '/Windows/ {print substr($0,5,4)}'); do
+    efibootmgr -q ${efibootmgr_a_flag} -b "${boot_entry}" || return 1
+  done
+
+  return 0
+}
+
 setup_windows_enabled() {
   if [ "$(puavo-conf puavo.grub.windows.enabled)" = 'true' ]; then
-    grubedit set "puavo_grub_windows_enabled=true"
+    grubedit set "puavo_grub_windows_enabled=true" || return 1
+    efi_boot_state_windows=active
   else
-    grubedit unset puavo_grub_windows_enabled
+    grubedit unset puavo_grub_windows_enabled || return 1
+    efi_boot_state_windows=inactive
   fi
+
+  if grep -q '^efivarfs ' /proc/mounts; then
+      efibootmgr_set_windows "${efi_boot_state_windows}" || return 1
+  fi
+
+  return 0
 }
 
 get_puavoconf_value() {

--- a/parts/core/puavo-conf/scripts/setup_grub_environment
+++ b/parts/core/puavo-conf/scripts/setup_grub_environment
@@ -104,12 +104,14 @@ efi_break_windows() {
   efi_mount_path=$(mount_efi_system_partition) || return 1
 
   if [ -d "${efi_mount_path}/EFI/Microsoft" ]; then
-    tar -C "${efi_mount_path}/EFI" -z -c -f "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" Microsoft || {
-      rm -rf "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz" || true
+    defused_windows_tmpfile=$(mktemp -p "${efi_mount_path}/EFI" 'Puavo-defused-Microsoft.tar.gz.tmp.XXXXXXXX')
+    tar -C "${efi_mount_path}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
+      rm -rf "${defused_windows_tmpfile}" || true
       umount "${efi_mount_path}" || return 1
       rm -rf "${efi_mount_path}"
       return 1
     }
+    mv "${defused_windows_tmpfile}" "${efi_mount_path}/EFI/Puavo-defused-Microsoft.tar.gz"
     rm -rf "${efi_mount_path}/EFI/Microsoft" || {
       umount "${efi_mount_path}" || return 1
       rm -rf "${efi_mount_path}"

--- a/parts/ltsp/client/puavo-conf-parameters.json
+++ b/parts/ltsp/client/puavo-conf-parameters.json
@@ -102,6 +102,11 @@
   "puavo.grub.timeout": {
     "default": "5"
   },
+  "puavo.grub.windows.defuse_efi_boot_when_disabled": {
+    "default": "false",
+    "description": "If true and Windows is disabled, Windows EFI boot is defused",
+    "typehint": "bool"
+  },
   "puavo.grub.windows.enabled": {
     "default": "true",
     "description": "If true and Windows is installed, show it in Grub boot menu",

--- a/parts/ltsp/puavo-install/Makefile
+++ b/parts/ltsp/puavo-install/Makefile
@@ -40,6 +40,7 @@ install : installdirs
 		puavo-install-and-update-ltspimages \
 		puavo-install-grub \
 		puavo-make-install-disk \
+		puavo-manage-efi \
 		puavo-reset-laptop-to-factory-defaults \
 		puavo-reset-windows \
 		puavo-set-root-password \

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -60,7 +60,7 @@ efibootmgr_windows() {
 }
 
 esp_mount() {
-  local esp_devpath esp_mountpath
+  local esp_devpath esp_boot_efi_mounts
 
   esp_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}') || return 1
   if [ -z "${esp_devpath}" ]; then
@@ -68,44 +68,43 @@ esp_mount() {
     return 1
   fi
 
-  esp_mountpath=$(awk "-vdev=${esp_devpath}" '$1 == dev {print $2}' /proc/mounts) || return 1
+  esp_boot_efi_mounts=$(awk "-vdev=${esp_devpath}" '$1 == dev && $2 == "/boot/efi" {print $2}' /proc/mounts) || return 1
 
-  # Mount only if not already mounted.
-  if [ -z "${esp_mountpath}" ]; then
-    esp_mountpath=/boot/efi
-    mkdir -p "${esp_mountpath}" || return 1
-    mount -onodev,nosuid "${esp_devpath}" "${esp_mountpath}" || return 1
+  # Umount if already mounted to /boot/efi to ensure we control mount options.
+  if [ -n "${esp_boot_efi_mounts}" ]; then
+    log warning '/boot/efi was already mounted, umounting it'
+    umount /boot/efi || return 1
   fi
 
-  echo "${esp_mountpath}"
+  mkdir -p /boot/efi || return 1
+  mount -onodev,nosuid "${esp_devpath}" /boot/efi || return 1
+  echo /boot/efi
 }
 
 esp_break_windows() {
-  local defused_windows_file esp_mountpath tmp_defused_windows_file
+  local defused_windows_file tmp_defused_windows_file
 
-  esp_mountpath=$(esp_mount) || return 1
-  g_umount_on_exit="${esp_mountpath}"
-  defused_windows_file="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
+  defused_windows_file='/boot/efi/EFI/Puavo-defused-Windows.tar.gz'
   tmp_defused_windows_file="${defused_windows_file}.tmp"
   rm -f "$tmp_defused_windows_file"
 
   if [ -e "$defused_windows_file" ]; then
     # nothing to do
-    if [ -d "${esp_mountpath}/EFI/Microsoft" ]; then
-      log info "cleaning up ${esp_mountpath}/EFI/Microsoft that should not exist"
-      rm -rf "${esp_mountpath}/EFI/Microsoft" || true
+    if [ -d '/boot/efi/EFI/Microsoft' ]; then
+      log info "cleaning up /boot/efi/EFI/Microsoft that should not exist"
+      rm -rf '/boot/efi/EFI/Microsoft' || true
     fi
     return 0
   fi
 
-  if [ ! -d "${esp_mountpath}/EFI/Microsoft" ]; then
+  if [ ! -d '/boot/efi/EFI/Microsoft' ]; then
     # not doing/logging anything, perhaps we do not have Windows installed
     # and that should be normal
     return 0
   fi
 
   log info 'defusing Windows...'
-  tar -C "${esp_mountpath}/EFI" -z -c -f "$tmp_defused_windows_file" Microsoft || {
+  tar -C '/boot/efi/EFI' -z -c -f "$tmp_defused_windows_file" Microsoft || {
     log err 'failed to defuse Windows (tar error)'
     rm -f "$tmp_defused_windows_file" || true
     return 1
@@ -115,8 +114,8 @@ esp_break_windows() {
     log err 'failed to defuse Windows (mv error)'
     return 1
   fi
-  if ! rm -rf "${esp_mountpath}/EFI/Microsoft"; then
-    log warning "error cleaning up ${esp_mountpath}/EFI/Microsoft"
+  if ! rm -rf '/boot/efi/EFI/Microsoft'; then
+    log warning "error cleaning up /boot/efi/EFI/Microsoft"
     return 1
   fi
 
@@ -126,11 +125,9 @@ esp_break_windows() {
 }
 
 esp_fix_windows() {
-  local defused_windows_file esp_mountpath tmp_defused_windows_file
+  local defused_windows_file tmp_defused_windows_file
 
-  esp_mountpath=$(esp_mount) || return 1
-  g_umount_on_exit="${esp_mountpath}"
-  defused_windows_file="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
+  defused_windows_file='/boot/efi/EFI/Puavo-defused-Windows.tar.gz'
   tmp_defused_windows_file="${defused_windows_file}.tmp"
   rm -f "$tmp_defused_windows_file"
 
@@ -140,9 +137,9 @@ esp_fix_windows() {
   fi
 
   log info 'repriming Windows...'
-  tar -C "${esp_mountpath}/EFI" -z -x -f "$defused_windows_file" || {
+  tar -C '/boot/efi/EFI' -z -x -f "$defused_windows_file" || {
     log err 'error repriming Windows (tar error)'
-    rm -rf "${esp_mountpath}/EFI/Microsoft" || true
+    rm -rf '/boot/efi/EFI/Microsoft' || true
     return 1
   }
   sync || true
@@ -254,6 +251,8 @@ flock -x -n "${lockfd}" || {
 trap on_exit EXIT
 
 echo "$$" >"${PID_FILE}"
+
+g_umount_on_exit=$(esp_mount)
 
 case "${g_cmd}" in
   enable-windows)

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -6,11 +6,16 @@ set -o pipefail
 g_exitval=1
 g_no_efi_is_ok=false
 g_cmd=
+g_umount_on_exit=
 PID_FILE=/run/puavo-manage-efi.pid # Locks this file to ensure only one puavo-manage-efi is running
 
 on_exit()
 {
   set +e
+
+  if [ -n "${g_umount_on_exit}" ]; then
+    umount "${g_umount_on_exit}" || logerr "Failed to umount '${g_umount_on_exit}'"
+  fi
 
   rm -f "${PID_FILE}"
 
@@ -62,6 +67,7 @@ esp_mount() {
     esp_mountpath=/boot/efi
     mkdir -p "${esp_mountpath}" || return 1
     mount -onodev,nosuid "${esp_devpath}" "${esp_mountpath}" || return 1
+    g_umount_on_exit="${esp_mountpath}"
   fi
 
   echo "${esp_mountpath}"
@@ -82,20 +88,15 @@ esp_break_windows() {
     defused_windows_tmpfile=$(mktemp -p "${esp_mountpath}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
     tar -C "${esp_mountpath}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
       rm -rf "${defused_windows_tmpfile}" || true
-      umount "${esp_mountpath}"
       return 1
     }
     mv "${defused_windows_tmpfile}" "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
-    rm -rf "${esp_mountpath}/EFI/Microsoft" || {
-      umount "${esp_mountpath}"
-      return 1
-    }
+    rm -rf "${esp_mountpath}/EFI/Microsoft" || return 1
+
     loginfo 'Windows defused.'
   else
     loginfo 'Nothing to do.'
   fi
-
-  umount "${esp_mountpath}"
 }
 
 esp_fix_windows() {
@@ -111,19 +112,14 @@ esp_fix_windows() {
     fi
     tar -C "${esp_mountpath}/EFI" -z -x -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || {
       rm -rf "${esp_mountpath}/EFI/Microsoft" || true
-      umount "${esp_mountpath}"
       return 1
     }
-    rm -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || {
-      umount "${esp_mountpath}"
-      return 1
-    }
+    rm -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || return 1
+
     loginfo 'Windows reprimed.'
   else
     loginfo 'Nothing to do.'
   fi
-
-  umount "${esp_mountpath}"
 }
 
 efi_disable_windows() {

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -18,13 +18,13 @@ on_exit()
   set +e
 
   if [ -n "${g_umount_on_exit}" ]; then
-    umount "${g_umount_on_exit}" || log err "Failed to umount '${g_umount_on_exit}'"
+    umount "${g_umount_on_exit}" || log err "failed to umount '${g_umount_on_exit}'"
   fi
 
   rm -f "${PID_FILE}"
 
   if [ ${g_exitval} -ne 0 ]; then
-    log err 'Failed!'
+    log err 'failed!'
   fi
 
   exit ${g_exitval}
@@ -66,43 +66,64 @@ esp_mount() {
 }
 
 esp_break_windows() {
-  local defused_windows_tmpfile esp_mountpath
+  local defused_windows_file esp_mountpath tmp_defused_windows_file
 
   esp_mountpath=$(esp_mount) || return 1
-  defused_windows_tmpfile="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz.tmp"
-  rm -f "$defused_windows_tmpfile"
+  defused_windows_file="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
+  tmp_defused_windows_file="${defused_windows_file}.tmp"
+  rm -f "$tmp_defused_windows_file"
 
-  if [ -d "${esp_mountpath}/EFI/Microsoft" ]; then
-    log info 'Defusing Windows...'
-    if [ -e "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-      log err "Failed to defuse Windows, '${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz' already exists"
-      return 1
+  if [ -e "$defused_windows_file" ]; then
+    # nothing to do
+    if [ -d "${esp_mountpath}/EFI/Microsoft" ]; then
+      log info "cleaning up ${esp_mountpath}/EFI/Microsoft that should not exist"
+      rm -rf "${esp_mountpath}/EFI/Microsoft" || true
     fi
-
-    tar -C "${esp_mountpath}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
-      rm -rf "${defused_windows_tmpfile}" || true
-      return 1
-    }
-    mv "${defused_windows_tmpfile}" "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
-    rm -rf "${esp_mountpath}/EFI/Microsoft" || return 1
-
-    log info 'Windows defused.'
-  else
-    log info 'Nothing to do.'
+    return 0
   fi
+
+  if [ ! -d "${esp_mountpath}/EFI/Microsoft" ]; then
+    # not doing/logging anything, perhaps we do not have Windows installed
+    # and that should be normal
+    return 0
+  fi
+
+  log info 'defusing Windows...'
+  tar -C "${esp_mountpath}/EFI" -z -c -f "$tmp_defused_windows_file" Microsoft || {
+    log err 'failed to defuse Windows (tar)'
+    rm -f "$tmp_defused_windows_file" || true
+    return 1
+  }
+  if ! mv "$tmp_defused_windows_file" "$defused_windows_file"; then
+    log err 'failed to defuse Windows (mv)'
+    return 1
+  fi
+  if ! rm -rf "${esp_mountpath}/EFI/Microsoft"; then
+    log warning "error cleaning up ${esp_mountpath}/EFI/Microsoft"
+    return 1
+  fi
+
+  log notice 'Windows defused'
+
+  return 0
 }
 
 esp_fix_windows() {
-  local defused_windows_tmpfile esp_mountpath
+  local defused_windows_file esp_mountpath tmp_defused_windows_file
+
+  esp_mountpath=$(esp_mount) || return 1
+  defused_windows_file="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
+  tmp_defused_windows_file="${defused_windows_file}.tmp"
+  rm -f "$tmp_defused_windows_file"
 
   esp_mountpath=$(esp_mount) || return 1
   defused_windows_tmpfile="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz.tmp"
   rm -f "$defused_windows_tmpfile"
 
   if [ -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-    log info 'Repriming Windows...'
+    log info 'repriming Windows...'
     if [ -e  "${esp_mountpath}/EFI/Microsoft" ]; then
-      log err "Failed to reprime Windows: '${esp_mountpath}/EFI/Microsoft' already exists"
+      log err "failed to reprime Windows: '${esp_mountpath}/EFI/Microsoft' already exists"
       return 1
     fi
     tar -C "${esp_mountpath}/EFI" -z -x -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || {
@@ -111,9 +132,9 @@ esp_fix_windows() {
     }
     rm -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || return 1
 
-    log info 'Windows reprimed.'
+    log info 'Windows reprimed'
   else
-    log info 'Nothing to do.'
+    log info 'nothing to do'
   fi
 }
 

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -1,6 +1,37 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
+set -o pipefail
+
+g_exitval=1
+g_no_efi_is_ok=false
+g_cmd=
+PID_FILE=/run/puavo-manage-efi.pid # Locks this file to ensure only one puavo-manage-efi is running
+
+on_exit()
+{
+  set +e
+
+  rm -f "${PID_FILE}"
+
+  if [ ${g_exitval} -ne 0 ]; then
+    logerr 'Failed!'
+  fi
+
+  exit ${g_exitval}
+}
+
+loginfo() {
+  printf "INFO: %s\n" "$1" >&2
+}
+
+logwarning() {
+  printf "WARNING: %s\n" "$1" >&2
+}
+
+logerr() {
+  printf "ERROR: %s\n" "$1" >&2
+}
 
 efibootmgr_windows() {
   efibootmgr_flag=$1
@@ -29,9 +60,9 @@ efi_break_windows() {
   efi_mount_path=$(mount_efi_system_partition) || return 1
 
   if [ -d "${efi_mount_path}/EFI/Microsoft" ]; then
-    echo 'Defusing Windows...' >&2
+    loginfo 'Defusing Windows...'
     if [ -e "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-      echo "Failed to defuse Windows, '${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz' already exists" >&2
+      logerr "Failed to defuse Windows, '${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz' already exists"
       return 1
     fi
 
@@ -48,7 +79,9 @@ efi_break_windows() {
       rm -rf "${efi_mount_path}"
       return 1
     }
-    echo 'Windows defused.' >&2
+    loginfo 'Windows defused.'
+  else
+    loginfo 'Nothing to do.'
   fi
 
   umount "${efi_mount_path}" || return 1
@@ -59,9 +92,9 @@ efi_fix_windows() {
   efi_mount_path=$(mount_efi_system_partition) || return 1
 
   if [ -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-    echo 'Repriming Windows...' >&2
+    loginfo 'Repriming Windows...'
     if [ -e  "${efi_mount_path}/EFI/Microsoft" ]; then
-      echo "Failed to reprime Windows: '${efi_mount_path}/EFI/Microsoft' already exists" >&2
+      logerr "Failed to reprime Windows: '${efi_mount_path}/EFI/Microsoft' already exists"
       return 1
     fi
     tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
@@ -75,7 +108,9 @@ efi_fix_windows() {
       rm -rf "${efi_mount_path}"
       return 1
     }
-    echo 'Windows reprimed.' >&2
+    loginfo 'Windows reprimed.'
+  else
+    loginfo 'Nothing to do.'
   fi
 
   umount "${efi_mount_path}" || return 1
@@ -84,7 +119,7 @@ efi_fix_windows() {
 
 efi_disable_windows() {
   if [ "$(puavo-conf puavo.grub.windows.defuse_efi_boot_when_disabled)" != 'true' ]; then
-    echo "puavo.grub.windows.defuse_efi_boot_when_disabled is not true, not disabling Windows EFI boot" >&2
+    logwarning "puavo.grub.windows.defuse_efi_boot_when_disabled is not true, not disabling Windows EFI boot"
     return 0
   fi
 
@@ -101,6 +136,11 @@ has_efi() {
   grep -q '^efivarfs ' /proc/mounts
 }
 
+usage() {
+  echo "Usage: $0 [OPTIONS] COMMAND"
+  echo "       $0 --help"
+}
+
 usage_error() {
   local msg
 
@@ -108,23 +148,76 @@ usage_error() {
   shift
   
   echo "ERROR: ${msg}" >&2
-  echo "Usage: $0 enable-windows|disable-windows" >&2
+  usage >&2
 
   exit 1
 }
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        -h|--help)
+          shift
+          {
+            usage
+            echo
+            echo "Manage EFI boot. Modifies EFI boot order and ESP."
+            echo
+            echo "Commands:"
+            echo "    disable-windows              disable Windows"
+            echo "    enable-windows               enable Windows"
+            echo
+            echo "Options:"
+            echo "    --no-efi-is-ok               exit with status 0 if the system does not use EFI"
+            echo "    -h, --help                   print help and exit"
+            echo
+          } >&2
+          exit 0
+          ;;
+        --no-efi-is-ok)
+          shift
+          g_no_efi_is_ok=true
+          ;;
+        --)
+          shift
+          break
+          ;;
+        -*)
+          usage_error "invalid argument '$1'"
+          ;;
+        *)
+          break
+          ;;
+    esac
+done
 
 if [ $# -ne 1 ]; then
   usage_error "invalid number of arguments ($#), expected 1"
 fi
 
-cmd=$1
+g_cmd=$1
 shift
 
 if ! has_efi; then
-  exit 0
+  if ${g_no_efi_is_ok}; then
+    logwarning "this system does not have EFI"
+    exit 0
+  else
+    logerr "this system does not have EFI"
+    exit 1
+  fi
 fi
 
-case "${cmd}" in
+exec {lockfd}<> "${PID_FILE}"
+flock -x -n "${lockfd}" || {
+    logerr "puavo-manage-efi is already running!"
+    exit 1
+}
+
+trap on_exit EXIT
+
+echo "$$" >"${PID_FILE}"
+
+case "${g_cmd}" in
   enable-windows)
     efi_enable_windows
   ;;
@@ -132,5 +225,7 @@ case "${cmd}" in
     efi_disable_windows
   ;;
   *)
-    usage_error "invalid command '${cmd}'"
+    usage_error "invalid command '${g_cmd}'"
 esac
+
+g_exitval=0

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -212,6 +212,11 @@ if ! has_efi; then
   fi
 fi
 
+if [ "$(id -u)" -ne 0 ]; then
+  echo 'You need to be root!' >&2
+  exit 1
+fi
+
 exec {lockfd}<> "${PID_FILE}"
 flock -x -n "${lockfd}" || {
     logerr "puavo-manage-efi is already running!"

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -152,7 +152,6 @@ esp_fix_windows() {
 
 efi_disable_windows() {
   if [ "$(puavo-conf puavo.grub.windows.defuse_efi_boot_when_disabled)" != 'true' ]; then
-    log warning "puavo.grub.windows.defuse_efi_boot_when_disabled is not true, not disabling Windows EFI boot"
     return 0
   fi
 

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -90,12 +90,12 @@ esp_break_windows() {
 
   log info 'defusing Windows...'
   tar -C "${esp_mountpath}/EFI" -z -c -f "$tmp_defused_windows_file" Microsoft || {
-    log err 'failed to defuse Windows (tar)'
+    log err 'failed to defuse Windows (tar error)'
     rm -f "$tmp_defused_windows_file" || true
     return 1
   }
   if ! mv "$tmp_defused_windows_file" "$defused_windows_file"; then
-    log err 'failed to defuse Windows (mv)'
+    log err 'failed to defuse Windows (mv error)'
     return 1
   fi
   if ! rm -rf "${esp_mountpath}/EFI/Microsoft"; then
@@ -116,26 +116,20 @@ esp_fix_windows() {
   tmp_defused_windows_file="${defused_windows_file}.tmp"
   rm -f "$tmp_defused_windows_file"
 
-  esp_mountpath=$(esp_mount) || return 1
-  defused_windows_tmpfile="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz.tmp"
-  rm -f "$defused_windows_tmpfile"
-
-  if [ -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-    log info 'repriming Windows...'
-    if [ -e  "${esp_mountpath}/EFI/Microsoft" ]; then
-      log err "failed to reprime Windows: '${esp_mountpath}/EFI/Microsoft' already exists"
-      return 1
-    fi
-    tar -C "${esp_mountpath}/EFI" -z -x -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || {
-      rm -rf "${esp_mountpath}/EFI/Microsoft" || true
-      return 1
-    }
-    rm -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || return 1
-
-    log info 'Windows reprimed'
-  else
-    log info 'nothing to do'
+  if [ ! -e "$defused_windows_file" ]; then
+    # nothing to do
+    return 0
   fi
+
+  log info 'repriming Windows...'
+  tar -C "${esp_mountpath}/EFI" -z -x -f "$defused_windows_file" || {
+    log err 'error repriming Windows (tar error)'
+    rm -rf "${esp_mountpath}/EFI/Microsoft" || true
+    return 1
+  }
+  rm -f "$defused_windows_file" || return 1
+
+  log info 'Windows reprimed'
 }
 
 efi_disable_windows() {

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -1,0 +1,136 @@
+#!/bin/sh
+
+set -eu
+
+efibootmgr_windows() {
+  efibootmgr_flag=$1
+  shift
+
+  for boot_entry in $(efibootmgr | awk '/Windows/ {print substr($0,5,4)}'); do
+    efibootmgr -q "${efibootmgr_flag}" -b "${boot_entry}" || return 1
+  done
+
+  return 0
+}
+
+mount_efi_system_partition() {
+  efi_system_partition_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}')
+
+  efi_system_partition_mountpath=$(mktemp -d -p / EFI_SYSTEM_PARTITION.XXXXXXXXXXXX)
+  mount -onodev,nosuid "${efi_system_partition_devpath}" "${efi_system_partition_mountpath}" || {
+    rm -rf "${efi_system_partition_mountpath}"
+    return 1
+  }
+
+  echo "${efi_system_partition_mountpath}"
+}
+
+efi_break_windows() {
+  efi_mount_path=$(mount_efi_system_partition) || return 1
+
+  if [ -d "${efi_mount_path}/EFI/Microsoft" ]; then
+    echo 'Defusing Windows...' >&2
+    if [ -e "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
+      echo "Failed to defuse Windows, '${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz' already exists" >&2
+      return 1
+    fi
+
+    defused_windows_tmpfile=$(mktemp -p "${efi_mount_path}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
+    tar -C "${efi_mount_path}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
+      rm -rf "${defused_windows_tmpfile}" || true
+      umount "${efi_mount_path}" || return 1
+      rm -rf "${efi_mount_path}"
+      return 1
+    }
+    mv "${defused_windows_tmpfile}" "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz"
+    rm -rf "${efi_mount_path}/EFI/Microsoft" || {
+      umount "${efi_mount_path}" || return 1
+      rm -rf "${efi_mount_path}"
+      return 1
+    }
+    echo 'Windows defused.' >&2
+  fi
+
+  umount "${efi_mount_path}" || return 1
+  rm -rf "${efi_mount_path}"
+}
+
+efi_fix_windows() {
+  efi_mount_path=$(mount_efi_system_partition) || return 1
+
+  if [ -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
+    echo 'Repriming Windows...' >&2
+    if [ -e  "${efi_mount_path}/EFI/Microsoft" ]; then
+      echo "Failed to reprime Windows: '${efi_mount_path}/EFI/Microsoft' already exists" >&2
+      return 1
+    fi
+    tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
+      rm -rf "${efi_mount_path}/EFI/Microsoft" || true
+      umount "${efi_mount_path}" || return 1
+      rm -rf "${efi_mount_path}"
+      return 1
+    }
+    rm -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
+      umount "${efi_mount_path}" || return 1
+      rm -rf "${efi_mount_path}"
+      return 1
+    }
+    echo 'Windows reprimed.' >&2
+  fi
+
+  umount "${efi_mount_path}" || return 1
+  rm -rf "${efi_mount_path}"
+}
+
+efi_disable_windows() {
+  if [ "$(puavo-conf puavo.grub.windows.defuse_efi_boot_when_disabled)" != 'true' ]; then
+    echo "puavo.grub.windows.defuse_efi_boot_when_disabled is not true, not disabling Windows EFI boot" >&2
+    return 0
+  fi
+
+  efibootmgr_windows -A || return 1
+  efi_break_windows
+}
+
+efi_enable_windows() {
+  efi_fix_windows || return 1
+  efibootmgr_windows -a
+}
+
+has_efi() {
+  grep -q '^efivarfs ' /proc/mounts
+}
+
+usage_error() {
+  local msg
+
+  msg=$1
+  shift
+  
+  echo "ERROR: ${msg}" >&2
+  echo "Usage: $0 enable-windows|disable-windows" >&2
+
+  exit 1
+}
+
+if [ $# -ne 1 ]; then
+  usage_error "invalid number of arguments ($#), expected 1"
+fi
+
+cmd=$1
+shift
+
+if ! has_efi; then
+  exit 0
+fi
+
+case "${cmd}" in
+  enable-windows)
+    efi_enable_windows
+  ;;
+  disable-windows)
+    efi_disable_windows
+  ;;
+  *)
+    usage_error "invalid command '${cmd}'"
+esac

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -94,6 +94,7 @@ esp_break_windows() {
     rm -f "$tmp_defused_windows_file" || true
     return 1
   }
+  sync || true
   if ! mv "$tmp_defused_windows_file" "$defused_windows_file"; then
     log err 'failed to defuse Windows (mv error)'
     return 1
@@ -127,6 +128,7 @@ esp_fix_windows() {
     rm -rf "${esp_mountpath}/EFI/Microsoft" || true
     return 1
   }
+  sync || true
   rm -f "$defused_windows_file" || return 1
 
   log info 'Windows reprimed'

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -9,33 +9,25 @@ g_cmd=
 g_umount_on_exit=
 PID_FILE=/run/puavo-manage-efi.pid # Locks this file to ensure only one puavo-manage-efi is running
 
+log() {
+  logger -t puavo-manage-efi -p "user.${1}" "$2" || true
+}
+
 on_exit()
 {
   set +e
 
   if [ -n "${g_umount_on_exit}" ]; then
-    umount "${g_umount_on_exit}" || logerr "Failed to umount '${g_umount_on_exit}'"
+    umount "${g_umount_on_exit}" || log err "Failed to umount '${g_umount_on_exit}'"
   fi
 
   rm -f "${PID_FILE}"
 
   if [ ${g_exitval} -ne 0 ]; then
-    logerr 'Failed!'
+    log err 'Failed!'
   fi
 
   exit ${g_exitval}
-}
-
-loginfo() {
-  printf "INFO: %s\n" "$1" >&2
-}
-
-logwarning() {
-  printf "WARNING: %s\n" "$1" >&2
-}
-
-logerr() {
-  printf "ERROR: %s\n" "$1" >&2
 }
 
 efibootmgr_windows() {
@@ -56,7 +48,7 @@ esp_mount() {
 
   esp_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}') || return 1
   if [ -z "${esp_devpath}" ]; then
-    logerr 'EFI system partition not found'
+    log err 'EFI system partition not found'
     return 1
   fi
 
@@ -79,9 +71,9 @@ esp_break_windows() {
   esp_mountpath=$(esp_mount) || return 1
 
   if [ -d "${esp_mountpath}/EFI/Microsoft" ]; then
-    loginfo 'Defusing Windows...'
+    log info 'Defusing Windows...'
     if [ -e "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-      logerr "Failed to defuse Windows, '${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz' already exists"
+      log err "Failed to defuse Windows, '${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz' already exists"
       return 1
     fi
 
@@ -93,9 +85,9 @@ esp_break_windows() {
     mv "${defused_windows_tmpfile}" "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
     rm -rf "${esp_mountpath}/EFI/Microsoft" || return 1
 
-    loginfo 'Windows defused.'
+    log info 'Windows defused.'
   else
-    loginfo 'Nothing to do.'
+    log info 'Nothing to do.'
   fi
 }
 
@@ -105,9 +97,9 @@ esp_fix_windows() {
   esp_mountpath=$(esp_mount) || return 1
 
   if [ -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-    loginfo 'Repriming Windows...'
+    log info 'Repriming Windows...'
     if [ -e  "${esp_mountpath}/EFI/Microsoft" ]; then
-      logerr "Failed to reprime Windows: '${esp_mountpath}/EFI/Microsoft' already exists"
+      log err "Failed to reprime Windows: '${esp_mountpath}/EFI/Microsoft' already exists"
       return 1
     fi
     tar -C "${esp_mountpath}/EFI" -z -x -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || {
@@ -116,15 +108,15 @@ esp_fix_windows() {
     }
     rm -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || return 1
 
-    loginfo 'Windows reprimed.'
+    log info 'Windows reprimed.'
   else
-    loginfo 'Nothing to do.'
+    log info 'Nothing to do.'
   fi
 }
 
 efi_disable_windows() {
   if [ "$(puavo-conf puavo.grub.windows.defuse_efi_boot_when_disabled)" != 'true' ]; then
-    logwarning "puavo.grub.windows.defuse_efi_boot_when_disabled is not true, not disabling Windows EFI boot"
+    log warning "puavo.grub.windows.defuse_efi_boot_when_disabled is not true, not disabling Windows EFI boot"
     return 0
   fi
 
@@ -204,10 +196,10 @@ shift
 
 if ! has_efi; then
   if ${g_no_efi_is_ok}; then
-    logwarning "this system does not have EFI"
+    log warning "this system does not have EFI"
     exit 0
   else
-    logerr "this system does not have EFI"
+    log err "this system does not have EFI"
     exit 1
   fi
 fi
@@ -219,7 +211,7 @@ fi
 
 exec {lockfd}<> "${PID_FILE}"
 flock -x -n "${lockfd}" || {
-    logerr "puavo-manage-efi is already running!"
+    log err "puavo-manage-efi is already running!"
     exit 1
 }
 

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -44,44 +44,44 @@ efibootmgr_windows() {
   return 0
 }
 
-mount_efi_system_partition() {
-  efi_system_partition_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}') || return 1
-  if [ -z "${efi_system_partition_devpath}" ]; then
+esp_mount() {
+  esp_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}') || return 1
+  if [ -z "${esp_devpath}" ]; then
     logerr 'EFI system partition not found'
     return 1
   fi
 
-  efi_system_partition_mountpath=$(awk "-vdev=${efi_system_partition_devpath}" '$1 == dev {print $2}' /proc/mounts) || return 1
+  esp_mountpath=$(awk "-vdev=${esp_devpath}" '$1 == dev {print $2}' /proc/mounts) || return 1
 
   # Mount only if not already mounted.
-  if [ -z "${efi_system_partition_mountpath}" ]; then
-    efi_system_partition_mountpath=/boot/efi
-    mkdir -p "${efi_system_partition_mountpath}" || return 1
-    mount -onodev,nosuid "${efi_system_partition_devpath}" "${efi_system_partition_mountpath}" || return 1
+  if [ -z "${esp_mountpath}" ]; then
+    esp_mountpath=/boot/efi
+    mkdir -p "${esp_mountpath}" || return 1
+    mount -onodev,nosuid "${esp_devpath}" "${esp_mountpath}" || return 1
   fi
 
-  echo "${efi_system_partition_mountpath}"
+  echo "${esp_mountpath}"
 }
 
-efi_break_windows() {
-  efi_mount_path=$(mount_efi_system_partition) || return 1
+esp_break_windows() {
+  esp_mountpath=$(esp_mount) || return 1
 
-  if [ -d "${efi_mount_path}/EFI/Microsoft" ]; then
+  if [ -d "${esp_mountpath}/EFI/Microsoft" ]; then
     loginfo 'Defusing Windows...'
-    if [ -e "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
-      logerr "Failed to defuse Windows, '${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz' already exists"
+    if [ -e "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" ]; then
+      logerr "Failed to defuse Windows, '${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz' already exists"
       return 1
     fi
 
-    defused_windows_tmpfile=$(mktemp -p "${efi_mount_path}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
-    tar -C "${efi_mount_path}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
+    defused_windows_tmpfile=$(mktemp -p "${esp_mountpath}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
+    tar -C "${esp_mountpath}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
       rm -rf "${defused_windows_tmpfile}" || true
-      umount "${efi_mount_path}"
+      umount "${esp_mountpath}"
       return 1
     }
-    mv "${defused_windows_tmpfile}" "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz"
-    rm -rf "${efi_mount_path}/EFI/Microsoft" || {
-      umount "${efi_mount_path}"
+    mv "${defused_windows_tmpfile}" "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
+    rm -rf "${esp_mountpath}/EFI/Microsoft" || {
+      umount "${esp_mountpath}"
       return 1
     }
     loginfo 'Windows defused.'
@@ -89,25 +89,25 @@ efi_break_windows() {
     loginfo 'Nothing to do.'
   fi
 
-  umount "${efi_mount_path}"
+  umount "${esp_mountpath}"
 }
 
-efi_fix_windows() {
-  efi_mount_path=$(mount_efi_system_partition) || return 1
+esp_fix_windows() {
+  esp_mountpath=$(esp_mount) || return 1
 
-  if [ -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" ]; then
+  if [ -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" ]; then
     loginfo 'Repriming Windows...'
-    if [ -e  "${efi_mount_path}/EFI/Microsoft" ]; then
-      logerr "Failed to reprime Windows: '${efi_mount_path}/EFI/Microsoft' already exists"
+    if [ -e  "${esp_mountpath}/EFI/Microsoft" ]; then
+      logerr "Failed to reprime Windows: '${esp_mountpath}/EFI/Microsoft' already exists"
       return 1
     fi
-    tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
-      rm -rf "${efi_mount_path}/EFI/Microsoft" || true
-      umount "${efi_mount_path}"
+    tar -C "${esp_mountpath}/EFI" -z -x -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || {
+      rm -rf "${esp_mountpath}/EFI/Microsoft" || true
+      umount "${esp_mountpath}"
       return 1
     }
-    rm -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
-      umount "${efi_mount_path}"
+    rm -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" || {
+      umount "${esp_mountpath}"
       return 1
     }
     loginfo 'Windows reprimed.'
@@ -115,7 +115,7 @@ efi_fix_windows() {
     loginfo 'Nothing to do.'
   fi
 
-  umount "${efi_mount_path}"
+  umount "${esp_mountpath}"
 }
 
 efi_disable_windows() {
@@ -125,11 +125,11 @@ efi_disable_windows() {
   fi
 
   efibootmgr_windows -A || return 1
-  efi_break_windows
+  esp_break_windows
 }
 
 efi_enable_windows() {
-  efi_fix_windows || return 1
+  esp_fix_windows || return 1
   efibootmgr_windows -a
 }
 

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -30,14 +30,30 @@ on_exit()
   exit ${g_exitval}
 }
 
+get_windows_boot_entries_to_change() {
+  efibootmgr | awk -v flag="$1" '
+    /Windows/ {
+      is_active = (substr($0, 9, 1) == "*")
+      if ((flag == "-A" && is_active) || flag == "-a" && !is_active) {
+        print substr($0, 5, 4)
+      }
+    }
+  '
+}
+
 efibootmgr_windows() {
-  local efibootmgr_flag boot_entry
+  local boot_entry efibootmgr_flag enable_or_disable_msg
 
   efibootmgr_flag=$1
-  shift
+  case "$efibootmgr_flag" in
+    -A) enable_or_disable_msg='disabling' ;;
+    -a) enable_or_disable_msg='enabling'  ;;
+     *) return 1;;
+  esac
 
-  for boot_entry in $(efibootmgr | awk '/Windows/ {print substr($0,5,4)}'); do
-    efibootmgr -q "${efibootmgr_flag}" -b "${boot_entry}" || return 1
+  for boot_entry in $(get_windows_boot_entries_to_change "$efibootmgr_flag"); do
+    log notice "${enable_or_disable_msg} Windows boot entry ${boot_entry}"
+    efibootmgr -q "$efibootmgr_flag" -b "$boot_entry" || return 1
   done
 
   return 0

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -66,9 +66,11 @@ esp_mount() {
 }
 
 esp_break_windows() {
-  local esp_mountpath defused_windows_tmpfile
+  local defused_windows_tmpfile esp_mountpath
 
   esp_mountpath=$(esp_mount) || return 1
+  defused_windows_tmpfile="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz.tmp"
+  rm -f "$defused_windows_tmpfile"
 
   if [ -d "${esp_mountpath}/EFI/Microsoft" ]; then
     log info 'Defusing Windows...'
@@ -77,7 +79,6 @@ esp_break_windows() {
       return 1
     fi
 
-    defused_windows_tmpfile=$(mktemp -p "${esp_mountpath}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
     tar -C "${esp_mountpath}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
       rm -rf "${defused_windows_tmpfile}" || true
       return 1
@@ -92,9 +93,11 @@ esp_break_windows() {
 }
 
 esp_fix_windows() {
-  local esp_mountpath
+  local defused_windows_tmpfile esp_mountpath
 
   esp_mountpath=$(esp_mount) || return 1
+  defused_windows_tmpfile="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz.tmp"
+  rm -f "$defused_windows_tmpfile"
 
   if [ -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" ]; then
     log info 'Repriming Windows...'

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -75,7 +75,6 @@ esp_mount() {
     esp_mountpath=/boot/efi
     mkdir -p "${esp_mountpath}" || return 1
     mount -onodev,nosuid "${esp_devpath}" "${esp_mountpath}" || return 1
-    g_umount_on_exit="${esp_mountpath}"
   fi
 
   echo "${esp_mountpath}"
@@ -85,6 +84,7 @@ esp_break_windows() {
   local defused_windows_file esp_mountpath tmp_defused_windows_file
 
   esp_mountpath=$(esp_mount) || return 1
+  g_umount_on_exit="${esp_mountpath}"
   defused_windows_file="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
   tmp_defused_windows_file="${defused_windows_file}.tmp"
   rm -f "$tmp_defused_windows_file"
@@ -129,6 +129,7 @@ esp_fix_windows() {
   local defused_windows_file esp_mountpath tmp_defused_windows_file
 
   esp_mountpath=$(esp_mount) || return 1
+  g_umount_on_exit="${esp_mountpath}"
   defused_windows_file="${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz"
   tmp_defused_windows_file="${defused_windows_file}.tmp"
   rm -f "$tmp_defused_windows_file"

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -45,13 +45,20 @@ efibootmgr_windows() {
 }
 
 mount_efi_system_partition() {
-  efi_system_partition_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}')
-
-  efi_system_partition_mountpath=$(mktemp -d -p / EFI_SYSTEM_PARTITION.XXXXXXXXXXXX)
-  mount -onodev,nosuid "${efi_system_partition_devpath}" "${efi_system_partition_mountpath}" || {
-    rm -rf "${efi_system_partition_mountpath}"
+  efi_system_partition_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}') || return 1
+  if [ -z "${efi_system_partition_devpath}" ]; then
+    logerr 'EFI system partition not found'
     return 1
-  }
+  fi
+
+  efi_system_partition_mountpath=$(awk "-vdev=${efi_system_partition_devpath}" '$1 == dev {print $2}' /proc/mounts) || return 1
+
+  # Mount only if not already mounted.
+  if [ -z "${efi_system_partition_mountpath}" ]; then
+    efi_system_partition_mountpath=/boot/efi
+    mkdir -p "${efi_system_partition_mountpath}" || return 1
+    mount -onodev,nosuid "${efi_system_partition_devpath}" "${efi_system_partition_mountpath}" || return 1
+  fi
 
   echo "${efi_system_partition_mountpath}"
 }
@@ -69,14 +76,12 @@ efi_break_windows() {
     defused_windows_tmpfile=$(mktemp -p "${efi_mount_path}/EFI" 'Puavo-defused-Windows.tar.gz.tmp.XXXXXXXX')
     tar -C "${efi_mount_path}/EFI" -z -c -f "${defused_windows_tmpfile}" Microsoft || {
       rm -rf "${defused_windows_tmpfile}" || true
-      umount "${efi_mount_path}" || return 1
-      rm -rf "${efi_mount_path}"
+      umount "${efi_mount_path}"
       return 1
     }
     mv "${defused_windows_tmpfile}" "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz"
     rm -rf "${efi_mount_path}/EFI/Microsoft" || {
-      umount "${efi_mount_path}" || return 1
-      rm -rf "${efi_mount_path}"
+      umount "${efi_mount_path}"
       return 1
     }
     loginfo 'Windows defused.'
@@ -84,8 +89,7 @@ efi_break_windows() {
     loginfo 'Nothing to do.'
   fi
 
-  umount "${efi_mount_path}" || return 1
-  rm -rf "${efi_mount_path}"
+  umount "${efi_mount_path}"
 }
 
 efi_fix_windows() {
@@ -99,13 +103,11 @@ efi_fix_windows() {
     fi
     tar -C "${efi_mount_path}/EFI" -z -x -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
       rm -rf "${efi_mount_path}/EFI/Microsoft" || true
-      umount "${efi_mount_path}" || return 1
-      rm -rf "${efi_mount_path}"
+      umount "${efi_mount_path}"
       return 1
     }
     rm -f "${efi_mount_path}/EFI/Puavo-defused-Windows.tar.gz" || {
-      umount "${efi_mount_path}" || return 1
-      rm -rf "${efi_mount_path}"
+      umount "${efi_mount_path}"
       return 1
     }
     loginfo 'Windows reprimed.'
@@ -113,8 +115,7 @@ efi_fix_windows() {
     loginfo 'Nothing to do.'
   fi
 
-  umount "${efi_mount_path}" || return 1
-  rm -rf "${efi_mount_path}"
+  umount "${efi_mount_path}"
 }
 
 efi_disable_windows() {

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -151,40 +151,40 @@ usage_error() {
 }
 
 while [ $# -gt 0 ]; do
-    case $1 in
-        -h|--help)
-          shift
-          {
-            usage
-            echo
-            echo "Manage EFI boot. Modifies EFI boot order and ESP."
-            echo
-            echo "Commands:"
-            echo "    disable-windows              disable Windows"
-            echo "    enable-windows               enable Windows"
-            echo
-            echo "Options:"
-            echo "    --no-efi-is-ok               exit with status 0 if the system does not use EFI"
-            echo "    -h, --help                   print help and exit"
-            echo
-          } >&2
-          exit 0
-          ;;
-        --no-efi-is-ok)
-          shift
-          g_no_efi_is_ok=true
-          ;;
-        --)
-          shift
-          break
-          ;;
-        -*)
-          usage_error "invalid argument '$1'"
-          ;;
-        *)
-          break
-          ;;
-    esac
+  case $1 in
+    -h|--help)
+      shift
+      {
+        usage
+        echo
+        echo "Manage EFI boot. Modifies EFI boot order and ESP."
+        echo
+        echo "Commands:"
+        echo "    disable-windows              disable Windows"
+        echo "    enable-windows               enable Windows"
+        echo
+        echo "Options:"
+        echo "    --no-efi-is-ok               exit with status 0 if the system does not use EFI"
+        echo "    -h, --help                   print help and exit"
+        echo
+      } >&2
+      exit 0
+      ;;
+    --no-efi-is-ok)
+      shift
+      g_no_efi_is_ok=true
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      usage_error "invalid argument '$1'"
+      ;;
+    *)
+      break
+      ;;
+  esac
 done
 
 if [ $# -ne 1 ]; then
@@ -211,8 +211,8 @@ fi
 
 exec {lockfd}<> "${PID_FILE}"
 flock -x -n "${lockfd}" || {
-    log err "puavo-manage-efi is already running!"
-    exit 1
+  log err "puavo-manage-efi is already running!"
+  exit 1
 }
 
 trap on_exit EXIT
@@ -222,12 +222,13 @@ echo "$$" >"${PID_FILE}"
 case "${g_cmd}" in
   enable-windows)
     efi_enable_windows
-  ;;
+    ;;
   disable-windows)
     efi_disable_windows
-  ;;
+    ;;
   *)
     usage_error "invalid command '${g_cmd}'"
+    ;;
 esac
 
 g_exitval=0

--- a/parts/ltsp/puavo-install/puavo-manage-efi
+++ b/parts/ltsp/puavo-install/puavo-manage-efi
@@ -34,6 +34,8 @@ logerr() {
 }
 
 efibootmgr_windows() {
+  local efibootmgr_flag boot_entry
+
   efibootmgr_flag=$1
   shift
 
@@ -45,6 +47,8 @@ efibootmgr_windows() {
 }
 
 esp_mount() {
+  local esp_devpath esp_mountpath
+
   esp_devpath=$(lsblk -n -l -o PATH,PARTTYPE | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}') || return 1
   if [ -z "${esp_devpath}" ]; then
     logerr 'EFI system partition not found'
@@ -64,6 +68,8 @@ esp_mount() {
 }
 
 esp_break_windows() {
+  local esp_mountpath defused_windows_tmpfile
+
   esp_mountpath=$(esp_mount) || return 1
 
   if [ -d "${esp_mountpath}/EFI/Microsoft" ]; then
@@ -93,6 +99,8 @@ esp_break_windows() {
 }
 
 esp_fix_windows() {
+  local esp_mountpath
+
   esp_mountpath=$(esp_mount) || return 1
 
   if [ -f "${esp_mountpath}/EFI/Puavo-defused-Windows.tar.gz" ]; then
@@ -147,7 +155,7 @@ usage_error() {
 
   msg=$1
   shift
-  
+
   echo "ERROR: ${msg}" >&2
   usage >&2
 

--- a/rules/grub/manifests/init.pp
+++ b/rules/grub/manifests/init.pp
@@ -30,6 +30,9 @@ class grub {
     'puavo.grub.timeout':
       script => 'setup_grub_environment';
 
+    'puavo.grub.windows.defuse_efi_boot_when_disabled':
+      script => 'setup_grub_environment';
+
     'puavo.grub.windows.enabled':
       script => 'setup_grub_environment';
   }


### PR DESCRIPTION
If `puavo.grub.windows.defuse_efi_boot_when_disabled` is `true`, then Windows EFI boot gets "defused" when Windows is disabled.

Defusing means:
- all Windows EFI boot entries are inactivated
- all Windows EFI boot manager files are archived

When Windows is re-enabled, Windows EFI Boot is reprimed automatically.