### PR TITLE
screenkeyboardcontroller: fix invalid dconf profile

### DIFF
--- a/rules/gnome_shell_extensions/manifests/init.pp
+++ b/rules/gnome_shell_extensions/manifests/init.pp
@@ -29,7 +29,7 @@ class gnome_shell_extensions {
       notify  => Exec['update dconf'],
       require => ::Dconf::Schemas::Schema['org.gnome.shell.extensions.screenkeyboardcontroller.gschema.xml'];
 
-    "/etc/dconf/db/screenkeyboardcontroller_${mode}.d/locks/screenkeyboardcontroller_${mode}_profile":
+    "/etc/dconf/db/screenkeyboardcontroller_${mode}.d/screenkeyboardcontroller_${mode}_profile":
       content => template('gnome_shell_extensions/dconf_screenkeyboardcontroller_profile'),
       notify  => Exec['update dconf'],
       require => ::Dconf::Schemas::Schema['org.gnome.shell.extensions.screenkeyboardcontroller.gschema.xml'];

--- a/rules/gnome_shell_extensions/templates/dconf_screenkeyboardcontroller_profile
+++ b/rules/gnome_shell_extensions/templates/dconf_screenkeyboardcontroller_profile
@@ -1,2 +1,2 @@
 [org/gnome/shell/extensions/screenkeyboardcontroller]
-mode=<%= @mode %>
+mode='<%= @mode %>'


### PR DESCRIPTION
GNOME Shell extension screenkeyboardcontroller did not work because gsettings always defaulted to `do_nothing` behavior. That's because Puppet generated invalid dconf profiles (strings values were not quoted).

This PR also moves profile files to correct directories; previously they were in `locks` dir.