### PR TITLE
puavo-reset-windows: wipefs windows partition before blkdiscard

### DIFF
--- a/debs/puavo-os/debian/control
+++ b/debs/puavo-os/debian/control
@@ -321,6 +321,7 @@ Depends: ${misc:Depends},
  ruby-highline,
  secure-delete,
  sudo,
+ util-linux,
  wget
 Description: Bits and pieces needed inside the LTSP chroot image.
  Bits and pieces needed inside the LTSP chroot image.

--- a/parts/ltsp/puavo-install/puavo-reset-windows
+++ b/parts/ltsp/puavo-install/puavo-reset-windows
@@ -569,6 +569,10 @@ reset_win()
     wim_image_index=$(print0_wim_image_index "$wim_image_name" "$win_product_name")
 
     loginfo "Securely erasing Windows on '${win_primary_partition_devpath}'"
+    wipefs -f -a "${win_primary_partition_devpath}" || {
+        logerr "Failed to run wipefs to '${win_primary_partition_devpath}'"
+        return 1
+    }
     blkdiscard "${win_primary_partition_devpath}" || {
         logerr "Failed to run blkdiscard to '${win_primary_partition_devpath}'"
         return 1


### PR DESCRIPTION
I've seen situations where blkdiscard has failed because the partition has filesystem signatures (blkdiscard makes various checks before proceeding). It does not seem to happen consistently, i.e. I'm not exactly sure what are the exact failure conditions.

But, since we are completely erasing the partition anyways, and re-creating the filesystem, wiping all signatures beforehand is a no-brainer fix.