### PR TITLE
debs/gnome-shell: disable screencast because it requires pipewire

### DIFF
--- a/debs/gnome-shell/puavo/patches/12-puavo-disable-screencast.patch
+++ b/debs/gnome-shell/puavo/patches/12-puavo-disable-screencast.patch
@@ -1,0 +1,26 @@
+Index: gnome-shell/js/dbusServices/screencast/screencastService.js
+===================================================================
+--- gnome-shell.orig/js/dbusServices/screencast/screencastService.js
++++ gnome-shell/js/dbusServices/screencast/screencastService.js
+@@ -272,7 +272,7 @@ var ScreencastService = class extends Se
+         super(ScreencastIface, '/org/gnome/Shell/Screencast');
+ 
+         this.hold(); // gstreamer initializing can take a bit
+-        this._canScreencast = ScreencastService.canScreencast();
++        this._canScreencast = false; // ScreencastService.canScreencast(); requires pipewire but we don't have it in Bookworm
+ 
+         Gst.init(null);
+         Gtk.init();
+Index: gnome-shell/js/ui/screenshot.js
+===================================================================
+--- gnome-shell.orig/js/ui/screenshot.js
++++ gnome-shell/js/ui/screenshot.js
+@@ -1321,7 +1321,7 @@ var ScreenshotUI = GObject.registerClass
+             new Gio.Settings({ schema_id: 'org.gnome.shell.keybindings' }),
+             Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
+             restrictedModes,
+-            showScreenRecordingUI
++            showScreenshotUI
+         );
+ 
+         Main.wm.addKeybinding(


### PR DESCRIPTION
This PR simply disables screencasting in Gnome Shell recorder and launches recorder in screenshot mode when screencasting was requested.

Closes #750 