### PR TITLE
fix: use a proper URL for puavo-os-pkg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "parts/pkg/packages"]
 	path = parts/pkg/packages
-	url = ../puavo-os-pkg.git
+	url = https://github.com/puavo-org/puavo-os-pkg


### PR DESCRIPTION
It is not possible for someone outside the organization to try out Puavo, if git submodules do not point to public URLs. Address the issue by pointing the existing submodule to its https URL.

Local override can be still done:

```
git submodule set-url <submodule path> <override URL>
git submodule sync # .git/config will point to the override URL
git checkout .gitmodules # however, don't update .gitmodules
```

Closes: https://github.com/puavo-org/puavo-os/issues/778