### PR TITLE
chore: githooks

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+git submodule deinit -f --all
+git submodule update --init

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+GIT_HOOKS="${0%/*}/"
+
+if [ "$1" = "rebase" ]; then
+  exec "$GIT_HOOKS/post-merge"
+fi


### PR DESCRIPTION
Add optional hooks for updating submodules when a branch is rebased or merged e.g., when `git pull [--rebase]` is executed.
    
Activation:
    
    git config core.hooksPath .githooks
    
Alternative:
    
    mkdir .git/hooks
    cp .githooks/* .git/hooks