### PR TITLE
Add new ERS mode: abitti2server

### DIFF
--- a/debs/puavo-os/debian/control
+++ b/debs/puavo-os/debian/control
@@ -132,6 +132,7 @@ Depends: ${misc:Depends},
  python3-aionotify,
  python3-dbus,
  python3-gi,
+ python3-validators,
  python3-websocket
 Description: Puavo Examination Room Server
  A script for managing virtual machines for examination room servers

--- a/debs/puavo-os/debian/control
+++ b/debs/puavo-os/debian/control
@@ -129,6 +129,7 @@ Architecture: all
 Depends: ${misc:Depends},
  gir1.2-ayatanaappindicator3-0.1,
  python3,
+ python3-aionotify,
  python3-dbus,
  python3-gi,
  python3-websocket

--- a/parts/ers/Makefile
+++ b/parts/ers/Makefile
@@ -2,6 +2,7 @@ prefix = /usr/local
 exec_prefix = $(prefix)
 bindir = $(exec_prefix)/bin
 datarootdir = $(prefix)/share
+pylibdir=$(prefix)/lib/python3/dist-packages
 
 ifeq ($(prefix), /usr/local)
 sysconfdir = $(prefix)/etc
@@ -36,6 +37,7 @@ installdirs:
 	mkdir -p $(DESTDIR)$(datarootdir)/locale/fi/LC_MESSAGES
 	mkdir -p $(DESTDIR)$(datarootdir)/locale/sv/LC_MESSAGES
 	mkdir -p $(DESTDIR)$(datarootdir)/puavo-conf/definitions
+	mkdir -p $(DESTDIR)$(pylibdir)/puavo_ers
 	mkdir -p $(DESTDIR)$(sysconfdir)/sudoers.d
 	mkdir -p $(DESTDIR)$(sysconfdir)/xdg/autostart
 
@@ -56,6 +58,9 @@ install: installdirs
 		puavo-ers.json
 	$(INSTALL_DATA) -t $(DESTDIR)$(sysconfdir)/xdg/autostart \
 		puavo-ers-startup.desktop
+	$(INSTALL_DATA) -t $(DESTDIR)$(pylibdir)/puavo_ers \
+		puavo_ers/*.py
+
 
 .PHONY: clean
 clean:

--- a/parts/ers/Makefile
+++ b/parts/ers/Makefile
@@ -47,10 +47,10 @@ install: installdirs
 		puavo-ers-abitti2server \
 		puavo-ers-abitti2server-networking \
 		puavo-ers-applet \
+		puavo-ers-naksu \
+		puavo-ers-naksu2 \
 		puavo-ers-startup \
-		puavo-ers-startvm \
-		puavo-run-naksu \
-		puavo-ers-naksu2
+		puavo-ers-startvm
 	$(INSTALL_DATA) -t $(DESTDIR)$(sysconfdir)/sudoers.d \
 		etc/sudoers.d/puavo-ers-applet
 	$(INSTALL_DATA) -t $(DESTDIR)$(datarootdir)/locale/de/LC_MESSAGES \

--- a/parts/ers/Makefile
+++ b/parts/ers/Makefile
@@ -44,6 +44,7 @@ installdirs:
 .PHONY: install
 install: installdirs
 	$(INSTALL_PROGRAM) -t $(DESTDIR)$(bindir) \
+		puavo-ers-abitti2server \
 		puavo-ers-abitti2server-networking \
 		puavo-ers-applet \
 		puavo-ers-startup \

--- a/parts/ers/Makefile
+++ b/parts/ers/Makefile
@@ -43,9 +43,13 @@ installdirs:
 
 .PHONY: install
 install: installdirs
-	$(INSTALL_PROGRAM) -t $(DESTDIR)$(bindir) puavo-ers-applet \
-		puavo-ers-startup puavo-ers-startvm puavo-run-naksu \
-		puavo-run-naksu2
+	$(INSTALL_PROGRAM) -t $(DESTDIR)$(bindir) \
+		puavo-ers-abitti2server-networking \
+		puavo-ers-applet \
+		puavo-ers-startup \
+		puavo-ers-startvm \
+		puavo-run-naksu \
+		puavo-ers-naksu2
 	$(INSTALL_DATA) -t $(DESTDIR)$(sysconfdir)/sudoers.d \
 		etc/sudoers.d/puavo-ers-applet
 	$(INSTALL_DATA) -t $(DESTDIR)$(datarootdir)/locale/de/LC_MESSAGES \

--- a/parts/ers/etc/sudoers.d/puavo-ers-applet
+++ b/parts/ers/etc/sudoers.d/puavo-ers-applet
@@ -1,2 +1,3 @@
 Defaults!/usr/bin/puavo-ers-applet env_keep+="DBUS_SESSION_BUS_ADDRESS XDG_RUNTIME_DIR"
-%puavo-ers      ALL=(:puavo) NOPASSWD: /usr/bin/puavo-ers-applet
+%puavo-ers      ALL = (:puavo) NOPASSWD: /usr/bin/puavo-ers-applet
+%puavo-ers      ALL =          NOPASSWD: /usr/bin/puavo-ers-abitti2server-networking

--- a/parts/ers/puavo-ers-abitti2server
+++ b/parts/ers/puavo-ers-abitti2server
@@ -162,10 +162,7 @@ def _main() -> int:
     naksu2_certs_dir_monitor = None
 
     _run_networking("start")
-    # TODO: the interface is not ready immediately and
-    # Naksu2 does not accept it. Small delay fixes it,
-    # so go find the real solution.
-    time.sleep(5)
+    puavo_ers.net.wait_interface(interface, timeout=5)
     try:
         _reset_abitti2server_domain_name()
         _launch_naksu2(interface)

--- a/parts/ers/puavo-ers-abitti2server
+++ b/parts/ers/puavo-ers-abitti2server
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+# Standard library imports
+import json
+import logging
+import os
+import os.path
+import re
+import subprocess
+import time
+import typing
+
+# Third-party imports
+import gi
+
+gi.require_version("Gdk", "4.0")
+from gi.repository import Gio
+from gi.repository import Gdk
+
+import validators
+
+import puavo_ers.asyncio
+import puavo_ers.conf
+import puavo_ers.prog
+
+_LOGGER = logging.getLogger(os.path.basename(__file__))
+_THIS_DIR = os.path.dirname(__file__)
+
+_NAKSU2_CERTS_DIR_PATH = os.path.expanduser("~/.local/share/digabi/naksu2/certs/")
+
+
+def _read_abitti2server_domain_name() -> typing.Optional[str]:
+    try:
+        with open(
+            os.path.join(_NAKSU2_CERTS_DIR_PATH, "domain.txt"),
+            "r",
+            encoding="utf-8",
+        ) as domain_file:
+            domain_name = domain_file.readline().strip()
+    except FileNotFoundError:
+        return None
+
+    if not validators.domain(domain_name):
+        raise RuntimeError("invalid domain name", domain_name)
+
+    if not domain_name.endswith(".koe.abitti.net"):
+        raise RuntimeError("invalid domain name", domain_name)
+
+    return domain_name
+
+
+def _reset_abitti2server_domain_name():
+    fqdn = _read_abitti2server_domain_name()
+    if fqdn:
+        _run_networking("set_domain", fqdn)
+    else:
+        _run_networking("del_domain")
+
+
+def _configure_naksu2(interface: str):
+    try:
+        os.makedirs(_NAKSU2_CERTS_DIR_PATH)
+    except FileExistsError:
+        pass
+
+    try:
+        with open(
+            os.path.expanduser("~/.local/share/digabi/naksu2/naksu2-config.json"),
+            "r",
+            encoding="utf-8",
+        ) as config_file:
+            config = json.load(config_file)
+    except FileNotFoundError:
+        config = {
+            "screen": "Settings",
+        }
+
+    config.pop("networkInterface", None)
+
+    config["networkInterface"] = {
+        "iface": interface,
+        "ifaceName": interface,
+    }
+
+    with open(
+        os.path.expanduser("~/.local/share/digabi/naksu2/naksu2-config.json"),
+        "w",
+        encoding="utf-8",
+    ) as config_file:
+        json.dump(config, config_file)
+
+
+def _get_wd(name):
+    if not re.match(r"^[a-z0-9]{1,32}$", name):
+        raise ValueError("invalid working directory name", name)
+
+    wd = os.path.join(os.path.expanduser("~/.puavo/puavo-ers/abitti2server"), name)
+
+    try:
+        os.makedirs(wd)
+    except FileExistsError:
+        pass
+
+    return wd
+
+
+def _run(prog_args, wd):
+    with open(os.path.join(wd, "stderr.log"), "w", encoding="utf-8") as stderr:
+        with open(os.path.join(wd, "stdout.log"), "w", encoding="utf-8") as stdout:
+            subprocess.check_call(
+                prog_args,
+                cwd=wd,
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+
+def _run_networking(*args):
+    return _run(
+        [
+            "sudo",
+            os.path.join(_THIS_DIR, "puavo-ers-abitti2server-networking"),
+        ]
+        + list(args),
+        _get_wd("networking"),
+    )
+
+
+def _launch_naksu2(interface):
+    _configure_naksu2(interface)
+
+    Gio.DesktopAppInfo.new("naksu2.desktop").launch(
+        context=Gdk.Display.open(os.environ["DISPLAY"]).get_app_launch_context()
+    )
+
+
+def _start_naksu2_certs_dir_monitor(loop):
+    naksu2_certs_dir_monitor = puavo_ers.asyncio.FileMonitor(
+        loop,
+        _NAKSU2_CERTS_DIR_PATH,
+        _naksu2_certs_changed,
+    )
+
+    naksu2_certs_dir_monitor.start()
+
+    return naksu2_certs_dir_monitor
+
+
+async def _naksu2_certs_changed(event):
+    _LOGGER.info("ainotify event: %s", event)
+    _reset_abitti2server_domain_name()
+
+
+def _main() -> int:
+    try:
+        interface = puavo_ers.conf.get_ers_abitti2server_interface()
+    except puavo_ers.conf.ValidationError as validation_error:
+        _LOGGER.error("invalid configuration: %s", str(validation_error))
+        return 1
+
+    loop = puavo_ers.asyncio.new_event_loop(logger=_LOGGER)
+    naksu2_certs_dir_monitor = None
+
+    _run_networking("start")
+    # TODO: the interface is not ready immediately and
+    # Naksu2 does not accept it. Small delay fixes it,
+    # so go find the real solution.
+    time.sleep(5)
+    try:
+        _reset_abitti2server_domain_name()
+        _launch_naksu2(interface)
+        naksu2_certs_dir_monitor = _start_naksu2_certs_dir_monitor(loop)
+        loop.run_forever()
+    finally:
+        if naksu2_certs_dir_monitor is not None:
+            naksu2_certs_dir_monitor.stop()
+        loop.close()
+        _run_networking("stop")
+
+    return 0
+
+
+if __name__ == "__main__":
+    puavo_ers.prog.logging_singleton_app(_main, _LOGGER)

--- a/parts/ers/puavo-ers-abitti2server-networking
+++ b/parts/ers/puavo-ers-abitti2server-networking
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+# This script is used for managing Abitti2 server networking. It reads
+# following Puavo conf options:
+#
+#   puavo.ers.abitti2server.interface
+#   puavo.ers.abitti2server.network
+#   puavo.ers.abitti2server.number
+#
+# Please see puavo-ers.json for more info about these conf options.
+#
+# Assuming aforementioned Puavo configuration is set, this script can
+# be used like so:
+#
+# To setup the network interface and start dnsmasq server, run:
+#   puavo-ers-abitti2server-networking start
+#
+# To stop the dnsmasq, run:
+#   puavo-ers-abitti2server-networking stop
+#
+# To set a A-record for the current host, run:
+#   puavo-ers-abitti2server-networking set_domain mydomain.example.invalid
+#
+# To delete the A-record, run:
+#   puavo-ers-abitti2server-networking del_domain
+#
+
+# Standard library imports
+import argparse
+import ipaddress
+import logging
+import os
+import os.path
+import signal
+import subprocess
+import time
+
+# Third-party imports
+import puavo_ers.conf
+import puavo_ers.net
+import puavo_ers.prog
+
+_THIS_NAME = os.path.basename(__file__)
+_LOGGER = logging.getLogger(_THIS_NAME)
+_DNSMASQ_PID_FILE = f"/run/{_THIS_NAME}-dnsmasq.pid"
+_DNSMASQ_LEASES_FILE = f"/var/lib/{_THIS_NAME}-dnsmasq.leases"
+_DNSMASQ_HOSTS_FILE = f"/var/lib/{_THIS_NAME}-dnsmasq.hosts"
+_LOCAL_DOMAIN = "puavo-ers-abitti2server.invalid"
+
+
+def _start_dhcp_dns_server(net: puavo_ers.net.Net) -> int:
+    args = [
+        "dnsmasq",
+        "--port=53",
+        f"--listen-address={net.host_address}",
+        f"--domain={_LOCAL_DOMAIN},{net.network},local",
+        "--domain-needed",
+        "--bogus-priv",
+        "--no-resolv",
+        "--no-hosts",
+        "--expand-hosts",
+        "--bind-interfaces",
+        f"--dhcp-leasefile={_DNSMASQ_LEASES_FILE}",
+        f"--dhcp-range={net.dhcp_hosts[0]},{net.dhcp_hosts[-1]},12h",
+        "--dhcp-option=option:router",  # Removes option:router from responses; there's no way out from this network
+        "--log-queries",
+        "--log-dhcp",
+        "--log-debug",
+        f"--pid-file={_DNSMASQ_PID_FILE}",
+        f"--addn-hosts={_DNSMASQ_HOSTS_FILE}",
+    ]
+    try:
+        user = os.environ["SUDO_USER"]
+    except KeyError:
+        # Let dnsmasq switch uid to it's default, normally nobody
+        pass
+    else:
+        # Ensure no tricks are being played, that the user actually exists.
+        user = subprocess.check_output(["id", "-un", user], timeout=2).decode().strip()
+        args.append(f"--user={user}")
+    _LOGGER.info("Spawning dnsmasq with args: %s", args)
+    subprocess.check_call(args)
+
+    return 0
+
+
+def _kill_dnsmasq(sig) -> bool:
+    with open(_DNSMASQ_PID_FILE, encoding="ascii") as dnsmasq_pid_file:
+        dnsmasq_pid = int(dnsmasq_pid_file.read().strip())
+
+    try:
+        os.kill(dnsmasq_pid, sig)
+    except ProcessLookupError:
+        os.unlink(_DNSMASQ_PID_FILE)
+        return True
+
+    return False
+
+
+def _stop_dhcp_dns_server() -> int:
+    # First gently.
+    if _kill_dnsmasq(15):
+        return 0
+
+    # Give it some time to die.
+    for _ in range(4):
+        time.sleep(0.5)
+        if _kill_dnsmasq(0):
+            return 0
+
+    # Then with force.
+    if _kill_dnsmasq(9):
+        _LOGGER.error("failed to kill dnsmasq gracefully!")
+        return 1
+
+    _LOGGER.critical("failed to kill dnsmasq!")
+    return 1
+
+
+def _command_start(interface, network, number, args):
+    net = puavo_ers.net.Net(interface, network, number)
+    net.up()
+
+    with open(_DNSMASQ_HOSTS_FILE, "w", encoding="utf-8"):
+        pass  # truncate before start
+
+    return _start_dhcp_dns_server(net)
+
+
+def _command_stop(interface, network, number, args) -> int:
+    net = puavo_ers.net.Net(interface, network, number)
+    try:
+        return _stop_dhcp_dns_server()
+    finally:
+        net.down()
+
+
+def _command_set_domain(interface, network, number, args) -> int:
+    ipv4_addr = ipaddress.IPv4Address(
+        puavo_ers.net.interface_addresses(interface)["AF_INET"][0]["addr"]
+    )
+    with open(_DNSMASQ_HOSTS_FILE, "w", encoding="utf-8") as dnsmasq_hosts_file:
+        dnsmasq_hosts_file.write(f"{ipv4_addr} {args.FQDN}\n")
+
+    return int(_kill_dnsmasq(signal.SIGHUP))
+
+
+def _command_del_domain(interface, network, number, args) -> int:
+    with open(_DNSMASQ_HOSTS_FILE, "w", encoding="utf-8"):
+        pass  # just truncate
+
+    return int(_kill_dnsmasq(signal.SIGHUP))
+
+
+def _main() -> int:
+    argparser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Setup networking for Abitti2 server",
+    )
+
+    subparsers = argparser.add_subparsers(dest="COMMAND", help="Available commands")
+
+    parser_start = subparsers.add_parser("start")
+    parser_start.set_defaults(func=_command_start)
+
+    parser_stop = subparsers.add_parser("stop")
+    parser_stop.set_defaults(func=_command_stop)
+
+    parser_set_domain = subparsers.add_parser("set_domain")
+    parser_set_domain.add_argument("FQDN")
+    parser_set_domain.set_defaults(func=_command_set_domain)
+
+    parser_del_domain = subparsers.add_parser("del_domain")
+    parser_del_domain.set_defaults(func=_command_del_domain)
+
+    args = argparser.parse_args()
+
+    try:
+        interface = puavo_ers.conf.get_ers_abitti2server_interface()
+        network = puavo_ers.conf.get_ers_abitti2server_network()
+        number = puavo_ers.conf.get_ers_abitti2server_number()
+    except puavo_ers.conf.ValidationError as validation_error:
+        _LOGGER.error("invalid configuration: %s", str(validation_error))
+        return 1
+
+    if os.getuid() != 0:
+        _LOGGER.error("must be root")
+        return 1
+
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    if hasattr(args, "func"):
+        return args.func(interface, network, number, args)
+
+    argparser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    puavo_ers.prog.logging_singleton_app(_main, _LOGGER)

--- a/parts/ers/puavo-ers-naksu
+++ b/parts/ers/puavo-ers-naksu
@@ -5,7 +5,7 @@ set -eu
 puavo_ers_dir="${HOME}/.puavo/puavo-ers"
 
 if ! mkdir -p "$puavo_ers_dir"; then
-  logger -p user.err -t puavo-run-naksu \
+  logger -p user.err -t puavo-ers-naksu \
          "could not create ${puavo_ers_dir}"
   exit 1
 fi
@@ -13,7 +13,7 @@ fi
 # naksu is self-updating so do not overwrite in case it exists
 if [ ! -x "${puavo_ers_dir}/naksu" ]; then
   if ! install -m 755 /opt/abitti-naksu/naksu "${puavo_ers_dir}/naksu"; then
-    logger -p user.err -t puavo-run-naksu \
+    logger -p user.err -t puavo-ers-naksu \
            "could not install ${puavo_ers_dir}/naksu"
     exit 1
   fi
@@ -22,11 +22,11 @@ fi
 cd "$puavo_ers_dir"
 
 while true; do
-  logger -p user.notice -t puavo-run-naksu 'starting up naksu'
+  logger -p user.notice -t puavo-ers-naksu 'starting up naksu'
   if ! /usr/bin/terminator -T 'naksu terminal' \
          --no-dbus "--working-directory=${puavo_ers_dir}" -x ./naksu \
          --self-update=enabled; then
-    logger -p user.err -t puavo-run-naksu 'error when running naksu'
+    logger -p user.err -t puavo-ers-naksu 'error when running naksu'
   fi
   sleep 5
 done

--- a/parts/ers/puavo-ers-naksu2
+++ b/parts/ers/puavo-ers-naksu2
@@ -4,31 +4,31 @@ set -eu
 
 workdir="${HOME}/.puavo/puavo-ers/naksu2-working-directory"
 
-logger -p user.notice -t puavo-run-naksu2 \
+logger -p user.notice -t puavo-ers-naksu2 \
        "preparing to run naksu2 in '${workdir}'"
 
 if ! mkdir -p "${workdir}"; then
-  logger -p user.err -t puavo-run-naksu2 "could not create '${workdir}'"
+  logger -p user.err -t puavo-ers-naksu2 "could not create '${workdir}'"
   exit 1
 fi
 
 if ! which naksu2 >/dev/null; then
-  logger -p user.err -t puavo-run-naksu2 'naksu2 not found'
+  logger -p user.err -t puavo-ers-naksu2 'naksu2 not found'
   exit 1
 fi
 
 if ! docker compose version; then
-  logger -p user.err -t puavo-run-naksu2 'docker compose'
+  logger -p user.err -t puavo-ers-naksu2 'docker compose'
   exit 1
 fi
 
 cd "${workdir}"
 
 while true; do
-  logger -p user.notice -t puavo-run-naksu2 'starting up naksu2'
+  logger -p user.notice -t puavo-ers-naksu2 'starting up naksu2'
   if ! /usr/bin/terminator -T 'naksu2 terminal' \
        --no-dbus "--working-directory=${workdir}" -x naksu2; then
-    logger -p user.err -t puavo-run-naksu2 'naksu2 failed'
+    logger -p user.err -t puavo-ers-naksu2 'naksu2 failed'
   fi
   sleep 5
 done

--- a/parts/ers/puavo-ers-startup
+++ b/parts/ers/puavo-ers-startup
@@ -12,10 +12,10 @@ case "$ers_mode" in
     exec sudo -g puavo /usr/bin/puavo-ers-applet "$@"
     ;;
   naksu)
-    exec /usr/bin/puavo-run-naksu
+    exec /usr/bin/puavo-ers-naksu
     ;;
   naksu2)
-    exec /usr/bin/puavo-run-naksu2
+    exec /usr/bin/puavo-ers-naksu2
     ;;
   abitti2server)
     exec /usr/bin/puavo-ers-abitti2server

--- a/parts/ers/puavo-ers-startup
+++ b/parts/ers/puavo-ers-startup
@@ -17,6 +17,9 @@ case "$ers_mode" in
   naksu2)
     exec /usr/bin/puavo-run-naksu2
     ;;
+  abitti2server)
+    exec /usr/bin/puavo-ers-abitti2server
+    ;;
   *)
     logger -p user.err -t puavo-ers-startup \
            "unsupported puavo.ers.mode value '${ers_mode}'"

--- a/parts/ers/puavo-ers.json
+++ b/parts/ers/puavo-ers.json
@@ -4,5 +4,20 @@
     "default": "ers-applet",
     "description": "The mode for examination room server desktop session",
     "typehint": "string"
+  },
+  "puavo.ers.abitti2server.interface": {
+    "default": "eth1",
+    "description": "Network interface to the Abitti2 server. This interface must not have IP address.",
+    "typehint": "string"
+  },
+  "puavo.ers.abitti2server.network": {
+    "default": "10.171.0.0/16",
+    "description": "IPv4 network with CIDR prefix length. CIDR prefix len must be 16.",
+    "typehint": "string"
+  },
+  "puavo.ers.abitti2server.number": {
+    "default": "1",
+    "description": "Abitti2 server number, must be between 1 and 254. Each server on the same LAN must have a unique number.",
+    "typehint": "integer"
   }
 }

--- a/parts/ers/puavo-ers.json
+++ b/parts/ers/puavo-ers.json
@@ -1,6 +1,6 @@
 {
   "puavo.ers.mode": {
-    "choices": [ "ers-applet", "naksu", "naksu2" ],
+    "choices": [ "ers-applet", "naksu", "naksu2", "abitti2server" ],
     "default": "ers-applet",
     "description": "The mode for examination room server desktop session",
     "typehint": "string"

--- a/parts/ers/puavo_ers/asyncio.py
+++ b/parts/ers/puavo_ers/asyncio.py
@@ -1,0 +1,69 @@
+"""
+Asyncio utils
+"""
+
+# Standard library imports
+import aionotify
+import asyncio
+import logging
+import os.path
+import signal
+
+__all__ = [
+    "FileMonitor",
+    "new_event_loop",
+]
+
+
+class FileMonitor:
+    def __init__(self, loop, path, cb):
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
+        self.__loop = loop
+        self.__watcher = aionotify.Watcher()
+        self.__watcher.watch(
+            path,
+            aionotify.Flags.MODIFY | aionotify.Flags.CREATE | aionotify.Flags.DELETE,
+        )
+        self.__task = None
+        self.__cb = cb
+
+    async def __run(self):
+        await self.__watcher.setup(self.__loop)
+        while True:
+            event = await self.__watcher.get_event()
+            await self.__cb(event)
+
+    def start(self):
+        self.__task = self.__loop.create_task(self.__run())
+
+    def stop(self):
+        self.__watcher.close()
+        if self.__task is not None:
+            self.__task.cancel()
+
+
+def new_event_loop(
+    stop_signals=(signal.SIGTERM, signal.SIGINT, signal.SIGQUIT, signal.SIGTSTP),
+    logger=None,
+):
+    if logger is None:
+        logger = logging.getLogger()
+
+    loop = asyncio.new_event_loop()
+
+    async def _stop_loop():
+        loop.stop()
+
+    def _stop(sig):
+        for stop_signal in stop_signals:
+            signal.signal(stop_signal, signal.SIG_IGN)
+        logger.info("stopping due to caught signal %r", sig)
+        for task in asyncio.all_tasks():
+            task.cancel()
+        asyncio.ensure_future(_stop_loop())
+
+    for sig in stop_signals:
+        loop.add_signal_handler(sig, _stop, sig)
+
+    return loop

--- a/parts/ers/puavo_ers/conf.py
+++ b/parts/ers/puavo_ers/conf.py
@@ -1,0 +1,137 @@
+"""
+Access Puavo configuration
+"""
+
+# Standard library imports
+import ipaddress
+import subprocess
+import typing
+
+# Third-party imports
+import puavo_ers.net
+
+_PuavoConfValueT = typing.TypeVar("_PuavoConfValueT")
+
+__all__ = [
+    "is_ers_mode_abitti2server",
+    "get_ers_abitti2server_interface",
+    "get_ers_abitti2server_network",
+    "get_ers_abitti2server_number",
+]
+
+
+class ValidationError(Exception):
+    def __init__(self, message, value):
+        self.puavoconf_key = None
+        self.value = value
+        self.message = message
+
+    def __str__(self) -> str:
+        if self.puavoconf_key:
+            return f"'{self.puavoconf_key}' has invalid value '{self.value}': {self.message}"
+
+        return f"invalid value '{self.value}': {self.message}"
+
+
+def _puavoconf_get(
+    puavoconf_key: str, validator: typing.Callable[[str], _PuavoConfValueT]
+) -> _PuavoConfValueT:
+    puavo_conf_string_value = (
+        subprocess.check_output(["puavo-conf", puavoconf_key]).rstrip().decode("utf-8")
+    )
+
+    try:
+        return validator(puavo_conf_string_value)
+    except ValidationError as validation_error:
+        validation_error.puavoconf_key = puavoconf_key
+        raise validation_error
+
+
+def validate_abitti2server_mode(s: str) -> str:
+    if s == "abitti2server":
+        return s
+
+    raise ValidationError("invalid mode", s)
+
+
+def validate_abitti2server_interface(
+    maybe_invalid_abitti2server_interface: str,
+) -> str:
+    if not maybe_invalid_abitti2server_interface:
+        return ""
+
+    if maybe_invalid_abitti2server_interface not in puavo_ers.net.interfaces():
+        raise ValidationError(
+            "interface does not exist", maybe_invalid_abitti2server_interface
+        )
+
+    return str(maybe_invalid_abitti2server_interface)
+
+
+def validate_abitti2server_network(
+    maybe_invalid_abitti2server_network_address: str,
+) -> str:
+    if not maybe_invalid_abitti2server_network_address:
+        return ""
+
+    network = ipaddress.IPv4Network(maybe_invalid_abitti2server_network_address)
+
+    if not network.is_private:
+        raise ValidationError(
+            "network is not private", maybe_invalid_abitti2server_network_address
+        )
+
+    if network.prefixlen != 16:
+        raise ValidationError(
+            "network has invalid size, CIDR prefix length must be 16",
+            maybe_invalid_abitti2server_network_address,
+        )
+
+    return str(network)
+
+
+def validate_abitti2server_number(
+    maybe_invalid_abitti2server_number: str,
+) -> int:
+    if not maybe_invalid_abitti2server_number:
+        raise ValidationError("number is invalid", maybe_invalid_abitti2server_number)
+
+    try:
+        number = int(maybe_invalid_abitti2server_number)
+    except ValueError as value_error:
+        raise ValidationError(
+            "number is invalid", maybe_invalid_abitti2server_number
+        ) from value_error
+
+    if 1 > number or number > 254:
+        raise ValidationError(
+            "number is not betwen 1 and 254", maybe_invalid_abitti2server_number
+        )
+
+    return number
+
+
+def is_ers_mode_abitti2server() -> bool:
+    try:
+        _puavoconf_get("puavo.ers.mode", validate_abitti2server_mode)
+    except ValidationError:
+        return False
+    return True
+
+
+def get_ers_abitti2server_interface() -> str:
+    return _puavoconf_get(
+        "puavo.ers.abitti2server.interface", validate_abitti2server_interface
+    )
+
+
+def get_ers_abitti2server_network() -> str:
+    return _puavoconf_get(
+        "puavo.ers.abitti2server.network", validate_abitti2server_network
+    )
+
+
+def get_ers_abitti2server_number() -> int:
+    return _puavoconf_get(
+        "puavo.ers.abitti2server.number", validate_abitti2server_number
+    )

--- a/parts/ers/puavo_ers/mp.py
+++ b/parts/ers/puavo_ers/mp.py
@@ -1,0 +1,47 @@
+# Standard library imports
+import multiprocessing
+import queue
+
+
+def run_tasks_until_one_dies(funcs):
+    results = []
+
+    result_queue = multiprocessing.Queue()
+
+    procs = [
+        multiprocessing.Process(target=func, kwargs={"result_queue": result_queue})
+        for func in funcs
+    ]
+
+    for p in procs:
+        p.start()
+
+    while True:
+        try:
+            result = result_queue.get(timeout=2)
+        except queue.Empty:
+            pass
+        else:
+            results.append(result)
+
+        if all(p.is_alive() for p in procs):
+            continue
+
+        break
+
+    for p in procs:
+        p.terminate()
+
+    for p in procs:
+        p.join(timeout=2)
+        p.kill()
+        p.join()
+
+    while True:
+        try:
+            result = result_queue.get(timeout=0)
+        except queue.Empty:
+            break
+        results.append(result)
+
+    return [p.exitcode for p in procs], results

--- a/parts/ers/puavo_ers/net.py
+++ b/parts/ers/puavo_ers/net.py
@@ -1,0 +1,212 @@
+"""
+Manage networking
+"""
+
+# Standard library imports
+import ipaddress
+import logging
+import os.path
+import subprocess
+import typing
+
+_LOGGER = logging.getLogger(os.path.basename(__file__))
+
+# Third-party imports
+import netifaces
+
+__all__ = [
+    "interfaces",
+    "interface_addresses",
+    "Net",
+]
+
+
+def interfaces() -> typing.List[str]:
+    return netifaces.interfaces()
+
+
+def interface_addresses(interface):
+    return {
+        netifaces.address_families[k]: v
+        for k, v in netifaces.ifaddresses(interface).items()
+    }
+
+
+class Net:
+    def __init__(self, interface_name: str, network: str, dhcp_subnet_number: int):
+        if interface_name not in interfaces():
+            raise ValueError("invalid interface_name", interface_name)
+        self.__interface_name = interface_name
+        self.__network = ipaddress.IPv4Network(network)
+        self.__dhcp_subnet = list(self.__network.subnets(8))[dhcp_subnet_number]
+        self.__was_managed = False
+
+    @property
+    def interface_name(self) -> str:
+        return self.__interface_name
+
+    @property
+    def host_address(self) -> ipaddress.IPv4Address:
+        return list(self.__dhcp_subnet.hosts())[0]
+
+    @property
+    def broadcast_address(self) -> ipaddress.IPv4Address:
+        return self.network.broadcast_address
+
+    @property
+    def network(self) -> ipaddress.IPv4Network:
+        return self.__network
+
+    @property
+    def interface_address(self) -> ipaddress.IPv4Interface:
+        return ipaddress.IPv4Interface(f"{self.host_address}/{self.network.prefixlen}")
+
+    @property
+    def dhcp_hosts(self) -> typing.List[ipaddress.IPv4Address]:
+        return list(self.__dhcp_subnet.hosts())[9:]
+
+    def up(self):
+        self.__was_managed, is_connected = self.nm_status()
+        if self.__was_managed and is_connected:
+            self.nm_disconnect()
+        self.nm_unmanage()
+        if list(interface_addresses(self.interface_name).keys()) != ["AF_PACKET"]:
+            _LOGGER.warning(
+                "interface %r is expected to have only OSI Layer 2 address, flushing all addresses",
+                self.interface_name,
+            )
+            self.addr_flush()
+        self.link_up()
+        subprocess.check_call(
+            [
+                "ip",
+                "addr",
+                "add",
+                str(self.interface_address),
+                "brd",
+                str(self.broadcast_address),
+                "dev",
+                self.interface_name,
+            ],
+            timeout=2,
+        )
+
+    def down(self):
+        try:
+            self.__link_cmd("down")
+        finally:
+            try:
+                subprocess.check_call(
+                    [
+                        "ip",
+                        "addr",
+                        "del",
+                        str(self.interface_address),
+                        "dev",
+                        self.interface_name,
+                    ],
+                    timeout=2,
+                )
+            finally:
+                if self.__was_managed:
+                    self.nm_unmanage()
+
+    def __enter__(self):
+        self.up()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.down()
+
+    def __link_cmd(self, cmd) -> None:
+        subprocess.check_call(
+            [
+                "ip",
+                "link",
+                "set",
+                self.interface_name,
+                cmd,
+            ],
+            timeout=2,
+        )
+
+    def __nmcli_manage_cmd(self, yes_or_no) -> None:
+        if yes_or_no not in ["yes", "no"]:
+            raise ValueError("invalid yes or no", yes_or_no)
+        subprocess.check_call(
+            [
+                "nmcli",
+                "device",
+                "set",
+                self.interface_name,
+                "managed",
+                yes_or_no,
+            ],
+            timeout=2,
+        )
+
+    def addr_flush(self) -> None:
+        subprocess.check_call(
+            [
+                "ip",
+                "addr",
+                "flush",
+                "dev",
+                self.interface_name,
+            ],
+            timeout=2,
+        )
+
+    def set_forwarding(self, enabled: bool) -> None:
+        with open(
+            f"/proc/sys/net/ipv4/conf/{self.interface_name}/forwarding",
+            "w",
+            encoding="ascii",
+        ) as forwarding_file:
+            forwarding_file.write(str(int(enabled)))
+
+    def enable_forwarding(self) -> None:
+        self.set_forwarding(True)
+
+    def disable_forwarding(self) -> None:
+        self.set_forwarding(False)
+
+    def link_up(self) -> None:
+        self.__link_cmd("up")
+
+    def link_down(self) -> None:
+        self.__link_cmd("down")
+
+    def nm_status(self) -> typing.Tuple[bool, bool]:
+        lines = subprocess.check_output(
+            [
+                "nmcli",
+                "-t",
+                "device",
+                "status",
+            ],
+            timeout=2,
+        ).decode()
+        for line in lines.splitlines():
+            iface, _, state, connection = line.strip().split(":")
+            if iface != self.interface_name:
+                continue
+            return state != "unmanaged", connection != ""
+        return False, False
+
+    def nm_manage(self) -> None:
+        self.__nmcli_manage_cmd("yes")
+
+    def nm_unmanage(self) -> None:
+        self.__nmcli_manage_cmd("no")
+
+    def nm_disconnect(self) -> None:
+        subprocess.check_call(
+            [
+                "nmcli",
+                "device",
+                "disconnect",
+                self.interface_name,
+            ],
+            timeout=10,
+        )

--- a/parts/ers/puavo_ers/net.py
+++ b/parts/ers/puavo_ers/net.py
@@ -7,6 +7,7 @@ import ipaddress
 import logging
 import os.path
 import subprocess
+import time
 import typing
 
 _LOGGER = logging.getLogger(os.path.basename(__file__))
@@ -19,6 +20,22 @@ __all__ = [
     "interface_addresses",
     "Net",
 ]
+
+
+def wait_interface(interface_name: str, *, timeout: float) -> bool:
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        addresses = netifaces.ifaddresses(interface_name)
+        if netifaces.AF_INET in addresses:
+            with open(
+                f"/sys/class/net/{interface_name}/operstate", encoding="ascii"
+            ) as operstate_file:
+                if operstate_file.read().strip().upper() == "UP":
+                    return True
+
+        time.sleep(0.5)
+
+    return False
 
 
 def interfaces() -> typing.List[str]:

--- a/parts/ers/puavo_ers/prog.py
+++ b/parts/ers/puavo_ers/prog.py
@@ -1,0 +1,90 @@
+"""
+Various program helpers
+"""
+
+# Standard library imports
+import contextlib
+import errno
+import fcntl
+import io
+import locale
+import logging
+import logging.handlers
+import os
+import os.path
+import sys
+
+__all__ = [
+    "LineBufferedLoggingStream",
+    "singleton",
+    "logging_singleton_app",
+]
+
+
+class LineBufferedLoggingStream(io.TextIOWrapper):
+    def __init__(self, logger, level):
+        self.__buffer = io.BytesIO()
+        self.__logger = logger
+        self.__level = level
+        super().__init__(self.__buffer, line_buffering=True)
+
+    def flush(self):
+        with self.buffer.getbuffer() as buf:
+            s = buf.tobytes().decode(locale.getencoding())
+            if s:
+                self.__logger.log(self.__level, s)
+        self.buffer.truncate(0)
+
+
+@contextlib.contextmanager
+def singleton():
+    this_prog_path = os.path.realpath(sys.argv[0])
+    with open(this_prog_path, "rb") as this_prog:
+        try:
+            fcntl.flock(this_prog, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as io_error:
+            if io_error.errno != errno.EAGAIN:
+                raise
+            raise RuntimeError(
+                f"program {this_prog_path!r} is already running)"
+            ) from io_error
+        yield
+
+
+def logging_singleton_app(
+    main_func,
+    logger,
+    stderr_logging_level=logging.ERROR,
+    stdout_logging_level=logging.WARNING,
+):
+    original_stderr = sys.stderr
+
+    if stderr_logging_level is not None:
+        sys.stderr = LineBufferedLoggingStream(logger, stderr_logging_level)
+    if stdout_logging_level is not None:
+        sys.stdout = LineBufferedLoggingStream(logger, stdout_logging_level)
+
+    logging_handlers = [
+        logging.handlers.SysLogHandler(address="/dev/log"),
+        logging.StreamHandler(original_stderr),
+    ]
+
+    logging.basicConfig(
+        level=logging.INFO,
+        handlers=logging_handlers,
+        force=True,
+    )
+    try:
+        logger.info("acquiring singleton program lock")
+        with singleton():
+            logger.info("calling main function")
+            status = main_func()
+        logger.log(
+            logging.INFO if status == 0 else logging.ERROR,
+            "returned from main function, status %d",
+            status,
+        )
+    except Exception:
+        logger.exception("failed")
+        raise
+    sys.exit(status)

--- a/parts/ltsp/client/profile-overwrites/ers.json
+++ b/parts/ltsp/client/profile-overwrites/ers.json
@@ -1,6 +1,8 @@
 {
   "puavo.admin.autoreboot.enabled": "true",
   "puavo.dockerd.data_root_in_home": "true",
+  "puavo.ers.abitti2server.interface": "eth0",
+  "puavo.ers.abitti2server.network": "10.171.0.0/16",
   "puavo.guestlogin.enabled": "true",
   "puavo.guestlogin.mode": "automatic",
   "puavo.pkg.abitti-naksu2": "latest",


### PR DESCRIPTION
This PR in a nutshell:

- `puavo_ers` Python library, which contains basic building blocks for the logic (this library could be useful outside ERS too, but now it's here and names like so)
- All scripts in `ers` part have now common `puavo-ers-` prefix
- New Puavo confs (see `puavo-ers.json` for more info):
  - `puavo.ers.abitti2server.interface`
  - `puavo.ers.abitti2server.network`
  - `puavo.ers.abitti2server.number`
- New choice for `puavo.ers.mode`: `abitti2server`
- `puavo-ers-abitti2server` which takes care of running `puavo-ers-abitti2server-networking`, configuring `naksu2`, spawning `naksu2` and monitoring `naksu2` configuration for relevant changes (just domain for now).
- `puavo-ers-abitti2server-networking` wrapper for running `dnsmasq` for the exam network

This new ERS mode is configured like so:

```
puavo.profile.ers: true
puavo.ers.mode: abitti2server
```

To deploy multiple servers within the same exam network, give them each unique server number:

First server should have:
```
puavo.ers.abitti2server.number: 1
```

And the second:

```
puavo.ers.abitti2server.number: 2
```

and so on.

Closes #795 