### PR TITLE
feat: grant realtime priotities

### DIFF
--- a/rules/packages/manifests/init.pp
+++ b/rules/packages/manifests/init.pp
@@ -922,6 +922,11 @@ class packages {
       tag => [ 'tag_utils', 'tag_debian_nonfree', ];
   }
 
+  # Grant realtime priorities by creating /etc/security/limits.d/audio.conf.
+  Package['jackd2'] {
+    install_options => [ '--yes' ],
+  }
+
   # For some reason installing "wireguards-tools" prefers
   # to install some kernel packages we do not want.
   # Prevent this from happening by using "--no-install-recommends".


### PR DESCRIPTION
Grant realtime priorities for users within audio-group, in other words, desktop profile users. It's by practical means a requirement for plausible use of any audio software, such as sequencers and digital audio workstations.
    
See also: https://jackaudio.org/faq/linux_rt_config.html