### PR TITLE
abitti2server-networking: increase the size of exam subnets by 2bits

### DIFF
--- a/parts/ers/puavo_ers/net.py
+++ b/parts/ers/puavo_ers/net.py
@@ -55,7 +55,7 @@ class Net:
             raise ValueError("invalid interface_name", interface_name)
         self.__interface_name = interface_name
         self.__network = ipaddress.IPv4Network(network)
-        self.__dhcp_subnet = list(self.__network.subnets(8))[dhcp_subnet_number]
+        self.__dhcp_subnet = list(self.__network.subnets(6))[dhcp_subnet_number]
         self.__was_managed = False
 
     @property


### PR DESCRIPTION
This extends the dhcp range from 245 address to 1013 addresses. Plenty, I'd say.

It probably does not make sense to have so many clients in one exam network, but at least it's now possible.

And it still means there can still be 64 such subnets.