### PR TITLE
ers: add new ers mode 'abitti2server_examnet_unmanaged'

### DIFF
--- a/parts/ers/puavo-ers-abitti2server
+++ b/parts/ers/puavo-ers-abitti2server
@@ -110,6 +110,15 @@ async def _naksu2_certs_changed(event):
 
 def _main() -> int:
     try:
+        ers_mode = puavo_ers.conf.get_ers_mode()
+    except puavo_ers.conf.ValidationError as validation_error:
+        return 1
+
+    if ers_mode == "abitti2server_examnet_unmanaged":
+        _LOGGER.info("Not managing exam network.")
+        return 0
+
+    try:
         interface = puavo_ers.conf.get_ers_abitti2server_interface()
     except puavo_ers.conf.ValidationError as validation_error:
         _LOGGER.error("invalid configuration: %s", str(validation_error))

--- a/parts/ers/puavo-ers-startup
+++ b/parts/ers/puavo-ers-startup
@@ -48,7 +48,7 @@ open_in_terminal() {
 
 ers_mode="$(puavo-conf puavo.ers.mode)"
 case "$ers_mode" in
-  abitti2server)
+  abitti2server*)
     open_in_terminal "abitti2server" /opt/ktp-controller/ktp-controller
     ;;
   ers-applet)

--- a/parts/ers/puavo-ers.json
+++ b/parts/ers/puavo-ers.json
@@ -1,6 +1,6 @@
 {
   "puavo.ers.mode": {
-    "choices": [ "ers-applet", "naksu", "naksu2", "abitti2server" ],
+    "choices": [ "ers-applet", "naksu", "naksu2", "abitti2server", "abitti2server_examnet_unmanaged" ],
     "default": "ers-applet",
     "description": "The mode for examination room server desktop session",
     "typehint": "string"

--- a/parts/ers/puavo_ers/conf.py
+++ b/parts/ers/puavo_ers/conf.py
@@ -17,6 +17,7 @@ __all__ = [
     "get_ers_abitti2server_interface",
     "get_ers_abitti2server_network",
     "get_ers_abitti2server_number",
+    "get_ers_mode",
 ]
 
 
@@ -48,7 +49,7 @@ def _puavoconf_get(
 
 
 def validate_abitti2server_mode(s: str) -> str:
-    if s == "abitti2server":
+    if s.startswith("abitti2server"):
         return s
 
     raise ValidationError("invalid mode", s)
@@ -134,4 +135,10 @@ def get_ers_abitti2server_network() -> str:
 def get_ers_abitti2server_number() -> int:
     return _puavoconf_get(
         "puavo.ers.abitti2server.number", validate_abitti2server_number
+    )
+
+
+def get_ers_mode() -> str:
+    return _puavoconf_get(
+        "puavo.ers.mode", validate_abitti2server_mode
     )


### PR DESCRIPTION
When `puavo.ers.mode = abitti2server_examnet_unmanaged`, network interface is unmanaged and network related services (dhcp, dns) are not started.