### PR TITLE
Add foot and msmtp packages

### DIFF
--- a/rules/packages/manifests/init.pp
+++ b/rules/packages/manifests/init.pp
@@ -118,6 +118,7 @@ class packages {
     , 'ethtool'
     , 'expect'
     , 'f2fs-tools'
+    , 'foot'
     , 'fping'
     , 'fwupd'
     , 'gawk'
@@ -312,7 +313,9 @@ class packages {
     [ 'tipp10' ]:
       tag => [ 'tag_education', 'tag_debian_desktop', ];
 
-    [ 'mutt' ]:
+    [ 'msmtp'
+    , `mutt`
+    ]:
       tag => [ 'tag_email', 'tag_debian_desktop', ];
 
     [ 'libvkd3d-shader1'


### PR DESCRIPTION
These are utilities I use on a daily basis and it is getting painful that they are not in the defaults image:

1. [`foot`](https://codeberg.org/dnkl/foot) is a cruft and slop free terminal emulator for Wayland. It is comparable to `urxvt` and alike terminal emulators for X11.
2. [`msmtp`](https://wiki.debian.org/msmtp) is an SMTP client I use. Both Mutt and GNOME Evolution are configured to pass-over SMTP tranfers for it, and I've using it for over 14 years.

Please, get this merged asap.