### PR TITLE
Bridge legacy JACK applications to Pipewire

### DIFF
--- a/rules/README
+++ b/rules/README
@@ -107,6 +107,10 @@ packages
 picaxe_udev_rules
     Some udev rules for making Picaxe microcontrollers work.
 
+pipewire_jack
+    pipewire-jack is drop-in replacement for libjack, which bridges
+    the legacy JACK applications to Pipewire.
+
 puavo_bash_completions
     Install bash completion files for some puavo tools.
 

--- a/rules/image/manifests/bundle/desktop.pp
+++ b/rules/image/manifests/bundle/desktop.pp
@@ -28,6 +28,7 @@ class image::bundle::desktop {
   include ::packages::languages::sv
   include ::packages::languages::uk
   include ::picaxe_udev_rules
+  include ::pipewire_jack
   include ::polkit_printers
   include ::progressive_web_applications::apps
   include ::puavo_pkg::packages

--- a/rules/packages/manifests/init.pp
+++ b/rules/packages/manifests/init.pp
@@ -709,6 +709,7 @@ class packages {
     , 'openprinting-ppds'
     , 'orca'
     , 'pcmciautils'
+    , 'pipewire-jack'
     , 'pipewire-libcamera'
     , 'plymouth'
     , 'plymouth-themes'

--- a/rules/pipewire_jack/files/pipewire-jack.conf
+++ b/rules/pipewire_jack/files/pipewire-jack.conf
@@ -1,0 +1,1 @@
+/usr/lib/x86_64-linux-gnu/pipewire-0.3/jack

--- a/rules/pipewire_jack/manifests/init.pp
+++ b/rules/pipewire_jack/manifests/init.pp
@@ -1,0 +1,15 @@
+class pipewire_jack {
+  include ::packages
+
+  exec {
+    '/sbin/ldconfig':
+      refreshonly => true;
+  }
+
+  file {
+    '/etc/ld.so.conf.d/pipewire-jack.conf':
+      require => Package['pipewire-jack'],
+      notify  => Exec['/sbin/ldconfig'],
+      source  => 'puppet:///modules/pipewire_jack/pipewire-jack.conf';
+  }
+}


### PR DESCRIPTION
Ensure that all audio applications used in German schools continue to work without issues by briding them to use Pipewire provided shim layer.

Closes: #846