### PR TITLE
gdm: Disable smartcard authentication

### DIFF
--- a/rules/gdm/files/setup_gdm
+++ b/rules/gdm/files/setup_gdm
@@ -96,6 +96,7 @@ accepted-usernames-for-userlist='${accepted_usernames_for_userlist}'
 allowed-failures=1
 disable-user-list=${disable_user_list}
 enable-guestuser=${enable_guestuser}
+enable-smartcard-authentication=false
 fallback-logo='/usr/share/icons/hicolor/48x48/emblems/emblem-debian-white.png'
 logo='$(puavo-conf puavo.greeter.logo)'
 


### PR DESCRIPTION
Without this override, gsd-smartcard loads softhsm2 on the login screen, which leaves GDM in a half-initialised state i.e., no user list and attempt to login hangs forever.

Closes: #850