### PR TITLE
core: increase syslog rate limit from 200/5secs to 400/5secs

### DIFF
--- a/parts/core/puavo-conf/scripts/setup_syslog
+++ b/parts/core/puavo-conf/scripts/setup_syslog
@@ -163,7 +163,7 @@ EOF
 # Provides support for local system logging.
 # Use rate limiting so that we do not fill up our /var
 # or overwhelm others.
-module(load="imuxsock" SysSock.RateLimit.Interval="5" SysSock.UseSpecialParser="off")
+module(load="imuxsock" SysSock.RateLimit.Interval="5" SysSock.RateLimit.Burst="400" SysSock.UseSpecialParser="off")
 
 module(load="imklog")   # provides kernel logging support
 #module(load="immark")  # provides --MARK-- message capability


### PR DESCRIPTION
KTP Controller will use (from 0.6.0 onwards) syslog for logging. KTP Controller has multiple logging components, Naksu2 being one of them. Naksu2 is notorious for verbose logging in it's initialization phase. It claims to use debug-level logging by default and there's no (at least easy and obcious way) to reduce it.

Increasing the maximum size of log bursts from 200/5secs to 400/5secs is not that big of a change, so it was decided to make it the default for all cases.