### PR TITLE
Container build optimized for Apple's BuildKit

### DIFF
--- a/.aux/create-uki-files
+++ b/.aux/create-uki-files
@@ -17,6 +17,12 @@ image_file=$4
 
 key_directory="${config_directory}/boot_keys/"
 
+# systemd-measure refuses group/world-accessible private keys.
+# git checkouts are 0644 and rootfs-sync-repo adds group-write (0664).
+chmod 0600 "${key_directory}"/tpm2-pcr-private-key*.pem \
+           "${key_directory}"/secure-boot.priv \
+           2>/dev/null || true
+
 # Find the art directory based on the image class, otherwise use the default
 art_directory="${config_directory}/art/allinone/"
 image_class_art_directory="${config_directory}/art/${image_class}/"

--- a/.aux/exec-in-container
+++ b/.aux/exec-in-container
@@ -13,6 +13,19 @@ mount -m -t sysfs    /sys     /sys     || mountpoint -q /sys
 mount -m -t proc     /proc    /proc    || mountpoint -q /proc
 mount -m -t devpts   /dev/pts /dev/pts || mountpoint -q /dev/pts
 
+# Hide Apple Rosetta's $HOME/.cache/rosetta leftover from rmdir(1).
+# The wrapper lives in the workspace copy inside this rootfs and is
+# bind-mounted only for this unshare, so the squashfs keeps stock rmdir.
+if [ -f /puavo-os/.aux/rmdir ]; then
+  mkdir -p /run
+  # Copy file contents (not a usrmerge symlink) before overlaying rmdir.
+  if [ ! -f /run/rmdir.real ] || [ -L /run/rmdir.real ]; then
+    cp -fL /usr/bin/rmdir /run/rmdir.real
+    chmod 0755 /run/rmdir.real
+  fi
+  mount --bind /puavo-os/.aux/rmdir /usr/bin/rmdir || true
+fi
+
 hostname "$machine"
 sudo -u "$user" env -u LANGUAGE \
     LANG=C.UTF-8 LC_ALL=C.UTF-8 \

--- a/.aux/exec-in-container
+++ b/.aux/exec-in-container
@@ -7,9 +7,12 @@ machine=$2
 user=$3
 shift 3
 
-mount -m -t sysfs    /sys     /sys
-mount -m -t proc     /proc    /proc
-mount -m -t devpts   /dev/pts /dev/pts
+# Accept already-mounted mountpoints (e.g. /proc bind-mounted for
+# Rosetta-translated chroots on Apple's container runtime).
+mount -m -t sysfs    /sys     /sys     || mountpoint -q /sys
+mount -m -t proc     /proc    /proc    || mountpoint -q /proc
+mount -m -t devpts   /dev/pts /dev/pts || mountpoint -q /dev/pts
+
 hostname "$machine"
 sudo -u "$user" env -u LANGUAGE \
     LANG=C.UTF-8 LC_ALL=C.UTF-8 \

--- a/.aux/generate-tpm-keys
+++ b/.aux/generate-tpm-keys
@@ -27,6 +27,7 @@ fi
 
 openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
   -out tpm2-pcr-private-key.pem
+chmod 0600 tpm2-pcr-private-key.pem
 openssl rsa -pubout -in tpm2-pcr-private-key.pem -out tpm2-pcr-public-key.pem
 
 openssl req -new -x509 -key tpm2-pcr-private-key.pem -days 36500 \

--- a/.aux/rmdir
+++ b/.aux/rmdir
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) Opinsys Oy 2026
+
+# rmdir wrapper for Rosetta-translated amd64 chroots.
+#
+# Apple's translator writes $HOME/.cache/rosetta on every amd64 exec.
+# Debian maintainer scripts that do
+#
+#   tmpdir=$(mktemp -d)
+#   cleanup() { rmdir "$tmpdir"; }
+#   trap cleanup EXIT
+#   HOME="$tmpdir" some-command
+#
+# then fail with "Directory not empty".  Strip that leftover and retry.
+# Bind-mounted over /usr/bin/rmdir only for the duration of
+# exec-in-container, so it never leaks into the squashfs.
+
+set -eu
+
+real=/run/rmdir.real
+if [ ! -x "${real}" ]; then
+  echo "rmdir: real binary ${real} is missing" >&2
+  exit 127
+fi
+
+"${real}" "$@" && exit 0
+
+for arg in "$@"; do
+  case "${arg}" in
+    -*) continue ;;
+  esac
+  rm -rf -- "${arg}/.cache/rosetta"
+  "${real}" "${arg}/.cache" 2>/dev/null || true
+done
+
+exec "${real}" "$@"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) Opinsys Oy 2026
+
+*
+!Dockerfile
+!scripts/
+!scripts/build-helper.sh
+!scripts/chroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,93 @@
+# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) Opinsys Oy 2026
+
+FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -o APT::Retries=3 update \
+    && apt-get -o APT::Retries=3 install -y --no-install-recommends \
+        bash \
+        bc \
+        binutils \
+        bsdiff \
+        build-essential \
+        bzip2 \
+        ca-certificates \
+        coreutils \
+        cpio \
+        curl \
+        dbus \
+        debianutils \
+        debootstrap \
+        devscripts \
+        diffutils \
+        dput \
+        efitools \
+        file \
+        findutils \
+        gawk \
+        git \
+        gnupg \
+        gosu \
+        grub-common \
+        grub2-common \
+        gzip \
+        locales \
+        lsb-release \
+        make \
+        openssh-client \
+        openssl \
+        passwd \
+        patch \
+        perl \
+        python3 \
+        rsync \
+        sbsigntool \
+        sed \
+        squashfs-tools \
+        sudo \
+        systemd \
+        systemd-boot-efi \
+        systemd-ukify \
+        python3-cryptography \
+        python3-pydantic \
+        libtss2-esys-3.0.2-0t64 \
+        libtss2-mu-4.0.1-0t64 \
+        libtss2-rc0t64 \
+        tar \
+        unzip \
+        util-linux \
+        wget \
+        xz-utils \
+        zstd \
+    && case "$(dpkg --print-architecture)" in \
+         amd64) apt-get -o APT::Retries=3 install -y --no-install-recommends \
+                  grub-efi-amd64-bin grub-efi-ia32-bin ;; \
+         *) echo "note: skipping x86_64/i386 GRUB modules" ;; \
+       esac \
+    && sed -i 's/^# *\(en_US.UTF-8 UTF-8\)$/\1/' /etc/locale.gen \
+    && locale-gen \
+    && rm -rf /var/lib/apt/lists/*
+
+# Mark this container as a Puavo OS build host so that the Makefile does
+# not attempt to run "setup-buildhost" (which expects systemd) at build
+# time.  The build directories themselves are created at runtime, because
+# a volume may be mounted over /home.
+RUN mkdir -p /etc/puavo \
+    && touch /etc/puavo/.is_puavo_buildhost
+
+ENV HOME=/home/puavo-builder \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+# debootstrap runs chroot with PATH=/sbin:/usr/sbin:/bin:/usr/bin, so
+# the wrapper must shadow the real chroot in /usr/sbin.
+RUN mv /usr/sbin/chroot /usr/sbin/chroot.real
+COPY --chmod=0755 scripts/chroot /usr/sbin/chroot
+COPY --chmod=0755 scripts/build-helper.sh /usr/local/bin/build-helper
+
+WORKDIR /workspace
+
+CMD ["/usr/local/bin/build-helper"]

--- a/README.md
+++ b/README.md
@@ -63,12 +63,19 @@ build directories and images live in the `puavo-os-build` and
 `puavo-os-output` volumes.  Built images can be copied out of the output
 volume with:
 
-    docker run --rm --volume puavo-os-output:/output         --volume "$PWD/images":/copy         debian:trixie-slim cp -a /output/. /copy/
+    docker run --rm --volume puavo-os-output:/output \
+        --volume "$PWD/images":/copy \
+        debian:trixie-slim cp -a /output/. /copy/
 
 By default the build targets amd64 images.  On Apple Silicon machines
 Docker Desktop and Apple's `container` tool run the amd64 container
 through Rosetta 2, which must be enabled.  Override the platform or
 architecture with `PLATFORM` and `TARGET_ARCH` if desired.
+
+Rosetta writes `$HOME/.cache/rosetta` on every translated exec.  The
+builder bind-mounts a small `rmdir` wrapper inside the rootfs so Debian
+maintainer scripts that `mktemp` a HOME and `rmdir` it on EXIT (notably
+`ghc-doc`) still succeed.  The wrapper is not part of the image.
 
 UKI PCR signing (`ukify --measure`) needs `systemd-measure` plus the
 `libtss2-*` libraries that systemd only Suggests.  Private keys are

--- a/README.md
+++ b/README.md
@@ -37,6 +37,61 @@ fresh Debian Bookworm virtual machine works with the steps listed
 above. Due to build process using a ramdisk /tmp, the virtual
 machine should have at least 16 GB of RAM for successful build.
 
+## Container build
+
+Images can also be built inside an OCI container, which avoids having to
+set up a dedicated Debian build host.  This is the recommended way to
+build on Apple hardware with e.g. Docker Desktop (which uses BuildKit by
+default) or Podman.  Clone with `--recursive` (or run
+`git submodule update --init --recursive`) first, then:
+
+    CONTAINER=docker ./scripts/build.sh
+
+The script builds the `puavo-os-builder` image and starts the build in the
+background.  Follow the build with Docker:
+
+    docker logs -f "$(docker ps -lq)"
+
+or with Apple's `container` tool:
+
+    container logs -f "$(container list -q)"
+
+Run the build in the foreground with `FOREGROUND=1` instead.
+
+The workspace (this repository) is bind-mounted into the container and the
+build directories and images live in the `puavo-os-build` and
+`puavo-os-output` volumes.  Built images can be copied out of the output
+volume with:
+
+    docker run --rm --volume puavo-os-output:/output         --volume "$PWD/images":/copy         debian:trixie-slim cp -a /output/. /copy/
+
+By default the build targets amd64 images.  On Apple Silicon machines
+Docker Desktop and Apple's `container` tool run the amd64 container
+through Rosetta 2, which must be enabled.  Override the platform or
+architecture with `PLATFORM` and `TARGET_ARCH` if desired.
+
+UKI PCR signing (`ukify --measure`) needs `systemd-measure` plus the
+`libtss2-*` libraries that systemd only Suggests.  Private keys are
+chmod'd to 0600 before signing because `rootfs-sync-repo` otherwise
+leaves them group-writable.  `verify-boot-components` needs `python3-pydantic`.
+
+Build-time variables:
+
+- `CONTAINER`: container tool (`docker`, `podman`, `container`)
+- `CONTAINER_CPUS` / `CONTAINER_MEMORY`: resources for the build
+  (default 8 CPUs / 16G)
+- `PLATFORM`: platform for the builder image (default `linux/amd64`)
+- `IMAGE_CLASSES`: comma-separated image classes (default `allinone`)
+- `TARGETS`: make targets to run
+  (default `rootfs-debootstrap rootfs-update rootfs-image`)
+- `TARGET_ARCH`: target architecture (default `amd64`)
+- `RELEASE_NAME`: image release name (default derived from git)
+- `REUSE_ROOTFS=1`: skip `rootfs-debootstrap` when the rootfs exists
+- `DEBOOTSTRAP_MIRROR`: override the debootstrap mirror
+- `FOREGROUND=1`: run the build container attached with `--rm`
+- `OUTPUT_DIR`: directory inside the container for built images
+  (default `/output`, the `puavo-os-output` volume)
+
 ## Using Puavo OS images
 
 Puavo OS image is not very useful in itself.

--- a/scripts/build-helper.sh
+++ b/scripts/build-helper.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) Opinsys Oy 2026
+
+set -euo pipefail
+
+readonly workspace=/workspace
+readonly builds_dir=/home
+readonly output_dir=${OUTPUT_DIR:-/output}
+
+if ((EUID == 0)); then
+  workspace_uid=$(stat -c %u "${workspace}")
+  workspace_gid=$(stat -c %g "${workspace}")
+
+  install -d -m 0755 -o "${workspace_uid}" -g "${workspace_gid}" \
+    "${output_dir}"
+
+  if ((workspace_uid != 0)); then
+    if ! getent group "${workspace_gid}" >/dev/null; then
+      groupadd --gid "${workspace_gid}" puavo-builder
+    fi
+    if ! getent passwd "${workspace_uid}" >/dev/null; then
+      useradd \
+        --uid "${workspace_uid}" \
+        --gid "${workspace_gid}" \
+        --home-dir "${HOME}" \
+        --no-create-home \
+        --no-log-init \
+        --shell /bin/bash \
+        puavo-builder
+    fi
+    printf 'puavo-builder ALL=(ALL) NOPASSWD: ALL\n' \
+      > /etc/sudoers.d/puavo-builder
+    chmod 0440 /etc/sudoers.d/puavo-builder
+    exec gosu "${workspace_uid}:${workspace_gid}" "$0" "$@"
+  fi
+fi
+
+cd "${workspace}"
+
+# parts/pkg/packages is a git submodule (puavo-os-pkg).  An empty
+# checkout makes "make -C pkg/packages all" fail late in rootfs-update.
+if [ ! -f parts/pkg/packages/Makefile ]; then
+  echo "error: git submodule parts/pkg/packages is not checked out" >&2
+  echo "hint: run 'git submodule update --init --recursive'" >&2
+  exit 1
+fi
+
+IFS=, read -r -a image_classes <<< "${IMAGE_CLASSES:-allinone}"
+for image_class in "${image_classes[@]}"; do
+  if [[ ! "${image_class}" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]]; then
+    echo "error: invalid image class name: ${image_class}" >&2
+    exit 1
+  fi
+done
+
+read -r -a make_targets <<< \
+  "${TARGETS:-rootfs-debootstrap rootfs-update rootfs-image}"
+
+make_args=()
+if [ -n "${TARGET_ARCH:-}" ]; then
+  make_args+=(target_arch="${TARGET_ARCH}")
+fi
+if [ -n "${DEBOOTSTRAP_MIRROR:-}" ]; then
+  make_args+=(debootstrap_mirror="${DEBOOTSTRAP_MIRROR}")
+fi
+
+release_name=${RELEASE_NAME:-}
+if [ -z "${release_name}" ]; then
+  release_name="container-$(git -C "${workspace}" describe \
+    --always --dirty 2>/dev/null || date -u +%Y%m%d%H%M%S)"
+fi
+make_args+=(release_name="${release_name}")
+
+rootfs_base=${PUAVO_ROOTFS:-${builds_dir}/imagebuilds}
+
+# The build directory may live on a volume mounted over /home, in which
+# case the marker file installed by the image is hidden.  Make sure that
+# "make" does not try to run "setup-buildhost" (which expects systemd).
+sudo mkdir -p "${rootfs_base}"
+sudo touch "${rootfs_base}/.is_puavo_buildhost"
+
+for image_class in "${image_classes[@]}"; do
+  rootfs_dir="${rootfs_base}/${image_class}"
+
+  if [ -z "${TARGETS:-}" ] &&
+     { [ -e "${rootfs_dir}" ] || [ -e "${rootfs_dir}.tmp" ]; }; then
+    if [ "${REUSE_ROOTFS:-0}" = 1 ]; then
+      echo "reusing existing rootfs ${rootfs_dir}"
+      make_targets=(rootfs-update rootfs-image)
+    else
+      echo "removing existing rootfs ${rootfs_dir}"
+      # Detach leftover /proc bind mounts (installed by the chroot
+      # wrapper for Rosetta) so that removal does not hit EBUSY.
+      sudo umount -l "${rootfs_dir}/proc" "${rootfs_dir}.tmp/proc" \
+        2>/dev/null || true
+      sudo rm -rf -- "${rootfs_dir}" "${rootfs_dir}.tmp"
+    fi
+  fi
+
+  # Bind-mount /proc into an existing rootfs so that Rosetta-translated
+  # binaries can resolve /proc/self/exe after "unshare --root".  The
+  # chroot wrapper does this during debootstrap; reuse and custom TARGETS
+  # skip that path and need the mount here.
+  for procdir in "${rootfs_dir}/proc" "${rootfs_dir}.tmp/proc"; do
+    if [ -d "${procdir}" ] && ! mountpoint -q "${procdir}" 2>/dev/null; then
+      sudo mount --bind /proc "${procdir}" 2>/dev/null || true
+    fi
+  done
+
+  make "${make_targets[@]}" "${make_args[@]}" \
+    image_class="${image_class}"
+done
+
+images_dir=${PUAVO_IMAGES:-${builds_dir}/puavo-os-images}
+if [ -d "${images_dir}" ]; then
+  install -d "${output_dir}"
+  rsync --archive "${images_dir}/" "${output_dir}/"
+fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) Opinsys Oy 2026
+
+set -euo pipefail
+
+CONTAINER=${CONTAINER:-docker}
+CONTAINER_CPUS=${CONTAINER_CPUS:-8}
+CONTAINER_MEMORY=${CONTAINER_MEMORY:-16G}
+PLATFORM=${PLATFORM:-linux/amd64}
+
+build_args=(
+  --platform "${PLATFORM}"
+  --tag puavo-os-builder:latest
+)
+if [ "$(basename -- "${CONTAINER}")" = container ]; then
+  build_args=(
+    --cpus "${CONTAINER_CPUS}"
+    --memory "${CONTAINER_MEMORY}"
+    "${build_args[@]}"
+  )
+fi
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+
+for volume in puavo-os-build puavo-os-output; do
+  "${CONTAINER}" volume inspect "${volume}" >/dev/null 2>&1 ||
+    "${CONTAINER}" volume create "${volume}" >/dev/null
+done
+
+"${CONTAINER}" build "${build_args[@]}" .
+
+run_args=(
+  --platform "${PLATFORM}"
+  --init
+  # The build needs mount and unshare; Apple's "container" runtime
+  # restricts capabilities by default.  Redundant on docker/podman,
+  # which already grant a superset by default.
+  --cap-add ALL
+  --cpus "${CONTAINER_CPUS}"
+  --memory "${CONTAINER_MEMORY}"
+  --env OUTPUT_DIR=/output
+  --volume "${PWD}:/workspace"
+  --volume puavo-os-build:/home
+  --volume puavo-os-output:/output
+)
+
+if [ "${FOREGROUND:-0}" = 1 ]; then
+  run_args+=(--rm)
+else
+  run_args+=(-d)
+fi
+
+for env in \
+  DEBOOTSTRAP_MIRROR \
+  IMAGE_CLASSES \
+  RELEASE_NAME \
+  REUSE_ROOTFS \
+  TARGET_ARCH \
+  TARGETS
+do
+  if [ -n "${!env:-}" ]; then
+    run_args+=(--env "${env}")
+  fi
+done
+
+"${CONTAINER}" run "${run_args[@]}" puavo-os-builder:latest "$@"

--- a/scripts/chroot
+++ b/scripts/chroot
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) Opinsys Oy 2026
+
+# Rosetta-aware chroot wrapper.
+#
+# Apple's "container" tool runs amd64 containers inside an arm64 VM using
+# Rosetta translation.  Translated binaries open /proc/self/exe at exec
+# time, which fails inside a chroot unless /proc is mounted there.  This
+# wrapper bind-mounts /proc into the chroot target before delegating to
+# the real chroot.  The mount is intentionally left in place, so that
+# subsequent "unshare --root" calls (which exec their command after
+# chrooting, before anything inside can mount /proc) work as well.
+#
+# This wrapper must shadow the real chroot: debootstrap runs chroot with
+# PATH=/sbin:/usr/sbin:/bin:/usr/bin, so the builder image installs this
+# script as /usr/sbin/chroot and keeps the coreutils binary as
+# /usr/sbin/chroot.real.
+
+set -eu
+
+real_chroot=/usr/sbin/chroot.real
+if [ ! -x "${real_chroot}" ]; then
+  echo "chroot: wrapper could not find the real chroot binary" >&2
+  exit 127
+fi
+
+[ $# -ge 2 ] || exec "${real_chroot}" "$@"
+
+target=$1
+
+if [ -d "${target}/proc" ] && ! mountpoint -q "${target}/proc" 2>/dev/null; then
+  mount --bind /proc "${target}/proc" 2>/dev/null || true
+fi
+
+exec "${real_chroot}" "$@"


### PR DESCRIPTION
E.g.,

```
brew install container
brew services start container
CONTAINER=container CONTAINER_MEMORY=16G ./scripts/build.sh
```

Defaults to Docker, and obviously works also with it. BuildKit's container cli is just the lowest common denominator.